### PR TITLE
Updated hero guides

### DIFF
--- a/disables.ts
+++ b/disables.ts
@@ -68,6 +68,7 @@ export const disables: IDisables = {
       disables: ["stun"],
     },
     // Level 25 talent makes Cold Feet be AoE and is cast in "area".
+	// The Aghanim's Shard on Ancient Apparition gives an Area stun on Ice Blast.
   ],
   "Anti-Mage": [
     {
@@ -223,7 +224,9 @@ export const disables: IDisables = {
       disables: ["stun"],
     },
   ],
-  Dazzle: [],
+  Dazzle: [
+	// Dazzle Aghanim's Shard gives him a Hero targeted Hex on Poison Touch.
+  ],
   "Death Prophet": [
     {
       skill: "death_prophet_silence",
@@ -400,7 +403,9 @@ export const disables: IDisables = {
       disables: ["stun"],
     },
   ],
-  Io: [],
+  Io: [
+	// Io Aghanim's Shard gives it an area stun on Tether.
+  ],
   Juggernaut: [],
   "Keeper of the Light": [
     {
@@ -934,15 +939,14 @@ export const disables: IDisables = {
     },
   ],
   Venomancer: [],
-  Viper: [
-    // Level 25 talent "Nethertoxin Silences" makes Nethertoxin be an area silence.
-  ],
+  Viper: [],
   Visage: [
     {
       skill: "visage_summon_familiars",
       affects: AbilityAffects.AREA,
       disables: ["stun"],
     },
+	// The Aghanim's Shard on Visage gives him another Area stun with self Stone Form.
   ],
   "Void Spirit": [
     {

--- a/heroBuilds.ts
+++ b/heroBuilds.ts
@@ -722,7 +722,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
 
   // YoonA plays hero
   "Ancient Apparition": {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -736,23 +736,23 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "ancient_apparition_chilling_touch",
           "ancient_apparition_cold_feet",
           `ancient_apparition_chilling_touch`,
-          `ancient_apparition_ice_vortex`,
           `ancient_apparition_cold_feet`,
-          "ancient_apparition_ice_blast",
-          `ancient_apparition_chilling_touch`,
-          `ancient_apparition_chilling_touch`,
-          "ancient_apparition_ice_vortex",
-          `special_bonus_unique_ancient_apparition_8`,
-          "ancient_apparition_ice_vortex",
+          `ancient_apparition_ice_vortex`,
           "ancient_apparition_ice_blast",
           `ancient_apparition_ice_vortex`,
+          `ancient_apparition_ice_vortex`,
+          "ancient_apparition_ice_vortex",
+          `special_bonus_unique_ancient_apparition_7`,
+          `ancient_apparition_chilling_touch`,
+          "ancient_apparition_ice_blast",
+          `ancient_apparition_chilling_touch`,
           `ancient_apparition_cold_feet`,
           "special_bonus_unique_ancient_apparition_3",
           `ancient_apparition_cold_feet`,
           "special_bonus_attributes",
           "ancient_apparition_ice_blast",
           "special_bonus_attributes",
-          "special_bonus_unique_ancient_apparition_4",
+          `special_bonus_unique_ancient_apparition_2`,
           "special_bonus_attributes",
           "special_bonus_attributes",
           "special_bonus_attributes",
@@ -763,10 +763,10 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           starting: [
             "tango",
             `tango`,
-            "faerie_fire",
+            `blood_grenade`,
             `enchanted_mango`,
             `enchanted_mango`,
-            `clarity`,
+            `branches`,
             `branches`,
             `branches`,
             "ward_observer",
@@ -780,22 +780,25 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           ],
           mid_game: [
             "glimmer_cape",
-            "aghanims_shard",
-            "force_staff",
+            `force_staff`,
+            `aghanims_shard`,
             `aether_lens`,
-            `tranquil_boots`,
           ],
           late_game: [
-            "aeon_disk",
-            "sheepstick",
-            `octarine_core`,
-            `ethereal_blade`,
+            `boots_of_bearing`,
+            `ultimate_scepter`,
+            `hurricane_pike`,
+            `sheepstick`,
+			`revenants_brooch`,
           ],
           situational: [
+            `ring_of_basilius`,
             `urn_of_shadows`,
-            `cyclone`,
-            `ultimate_scepter`,
-            `revenants_brooch`,
+			`rod_of_atos`,
+            `ethereal_blade`,
+            `octarine_core`,
+			`wind_waker`,
+			`guardian_greaves`,
             "lotus_orb",
             `travel_boots`,
           ],
@@ -803,21 +806,20 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "arcane_boots",
             "wind_lace",
             `glimmer_cape`,
-            "aghanims_shard",
-            `octarine_core`,
-            `aeon_disk`,
+			`force_staff`,
+            `aghanims_shard`,
           ],
           neutral: [
-            "trusty_shovel",
-            "arcane_ring",
+            `mysterious_hat`,
+            `pogo_stick`,
             "philosophers_stone",
-            //`nether_shawl`,
+            `eye_of_the_vizier`,
             "psychic_headband",
-            `ceremonial_robe`,
+            `quickening_charm`,
             `spy_gadget`,
-            `stormcrafter`,
+            `timeless_relic`,
             "seer_stone",
-            "book_of_shadows",
+            `pirate_hat`,
           ],
         },
       },
@@ -831,9 +833,9 @@ export const heroBuilds: { [key: string]: HeroContent } = {
       magic_wand: `Start with magic stick if you expect high frequency of spells being used on the lane.`,
       infused_raindrop: "Against magical burst.",
       arcane_boots:
-        "A core boots upgrade for mana sustain. It can be disasembled and Energy Booster can be later used on to craft Lotus Orb or Aeon Disk.",
+        `A core boots upgrade for mana sustain. Can build into Guardian Greaves or disassembled for Aether Lens.`,
       aghanims_shard:
-        "A core item that allows you to waveclear, do decent amounts of damage in the fights and cancel Blink Daggers.",
+        `A core item that gives you an added stun on Ice Blast.`,
       lotus_orb: "For reflect, dispel and armor.",
       ultimate_scepter: `An extremely late game item when you want to burst enemy heroes.`,
       revenants_brooch: `Goes well with the aghanims scepter in the very late game.`,
@@ -2636,7 +2638,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
 
   // YoonA plays hero (eidendota would play him as well, but YoonA had him already in the past)
   Bristleback: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.physical,
     builds: [
@@ -2671,7 +2673,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "special_bonus_attributes",
           "special_bonus_attributes",
           "special_bonus_attributes",
-          "special_bonus_unique_bristleback_3",
+          `special_bonus_spell_lifesteal_12`,
         ],
         items: {
           starting: [
@@ -2681,58 +2683,61 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "quelling_blade",
             `gauntlets`,
             `gauntlets`,
+			`ward_observer`,
           ],
           early_game: [
             `vanguard`,
+            `phase_boots`,
             `soul_ring`,
-            `boots`,
-            "magic_wand",
-            `hood_of_defiance`,
+            `magic_wand`,
           ],
           mid_game: [
+			`cloak`,
             "ultimate_scepter",
-            `black_king_bar`,
-            `aghanims_shard`,
-            `assault`,
+            `eternal_shroud`,
+            `crimson_guard`,
           ],
           late_game: [
-            `travel_boots`,
-            `abyssal_blade`,
-            `satanic`,
-            `overwhelming_blink`,
+            `black_king_bar`,
+            `aghanims_shard`,
+            `heart`,
+            `bloodstone`,
           ],
           situational: [
-            `phase_boots`,
+            `power_treads`,
             `pipe`,
-            `crimson_guard`,
-            `eternal_shroud`,
-            `arcane_boots`,
-            `heavens_halberd`,
+            `blade_mail`,
+            `abyssal_blade`,
             `guardian_greaves`,
-            `wraith_pact`,
+            `heavens_halberd`,
+            `greater_crit`,
+            `overwhelming_blink`,
             `lotus_orb`,
             `sphere`,
             `shivas_guard`,
+			`satanic`,
+			`travel_boots`,
           ],
           core: [
             "vanguard",
             `soul_ring`,
-            `boots`,
-            "hood_of_defiance",
+            `phase_boots`,
+			`cloak`,
             `ultimate_scepter`,
+            `eternal_shroud`,
             `black_king_bar`,
           ],
           neutral: [
-            `occult_bracelet`,
+            `lance_of_pursuit`,
             `broom_handle`,
             `vambrace`,
-            //`dagger_of_ristul`,
+            `vampire_fangs`,
             `cloak_of_flames`,
             `ogre_seal_totem`,
             `havoc_hammer`,
-            `penta_edged_sword`,
+            `trickster_cloak`,
             `giants_ring`,
-            `mirror_shield`,
+            `fallen_sky`,
           ],
         },
       },
@@ -2740,19 +2745,19 @@ export const heroBuilds: { [key: string]: HeroContent } = {
     ability_tooltips: {
       bristleback_viscous_nasal_goo:
         "You can skill Viscious Nasal Goo on level one if you are fighting on the rune, or on level two if you see an opportunity to run down the opponent`s hero on the lane.",
-      special_bonus_unique_bristleback_3:
-        "You should generally be looking to transition to right-clicker in late game and this talent helps with that.",
+      /* special_bonus_unique_bristleback_3:
+        "You should generally be looking to transition to right-clicker in late game and this talent helps with that.", */
     },
     item_tooltips: {
       magic_wand: `Start with magic stick if you expect high frequency of spells being used on the lane.`,
       vanguard:
         "A core item that makes you significantly harder to kill. Allows you to dive, creepskip and clear stacks with ease. Can be disassembled.",
       soul_ring: "A core item that helps with mana sustain.",
-      hood_of_defiance: "A core item that tanks you up against magical damage.",
+      cloak: "A core item that tanks you up against magical damage.",
       ultimate_scepter:
         "A core item that allows you to build up Warpath stacks faster as it makes Viscious Nasal Goo have no cast point. Adds to AoE control.",
       aghanims_shard: "For more Quill stacks and AoE slow.",
-      pipe: "Against heavy magical damage lineups.",
+      pipe: `Against heavy magical damage lineups as well as the tormentor.`,
       crimson_guard: "Against high attack speed heroes and multiple units.",
       heavens_halberd: "Especially good against ranged right-clickers.",
       lotus_orb: "For reflect, dispel(e.g. Spirit Vessel debuff) and armor.",
@@ -4367,7 +4372,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Dawnbreaker: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.neutral,
     builds: [
@@ -4378,8 +4383,8 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "https://steamcommunity.com/sharedfiles/filedetails/?id=2699917167",
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         abilities: [
-          "dawnbreaker_fire_wreath", // 1
-          "dawnbreaker_celestial_hammer", // 2
+          `dawnbreaker_celestial_hammer`, // 1
+          `dawnbreaker_fire_wreath`, // 2
           "dawnbreaker_celestial_hammer", // 3
           "dawnbreaker_fire_wreath", // 4   equals to `starbreaker`
           "dawnbreaker_celestial_hammer", // 5
@@ -4407,11 +4412,13 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         items: {
           starting: [
             `tango`,
-            `flask`,
-            `orb_of_venom`,
+            `tango`,
+            `blood_grenade`,
             `enchanted_mango`,
+			`circlet`,
+			`branches`,
+			`branches`,
             `ward_observer`,
-            `ward_sentry`,
           ],
           early_game: [
             `arcane_boots`,
@@ -4421,23 +4428,24 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           ],
           mid_game: [
             `holy_locket`,
-            `tranquil_boots`,
+            `guardian_greaves`,
             `ultimate_scepter`,
-            `lotus_orb`,
+            `pipe`,
           ],
           late_game: [
-            `aghanims_shard`,
-            `boots_of_bearing`,
-            `wraith_pact`,
-            `black_king_bar`,
+            `force_staff`,
+			`solar_crest`,
+			`aghanims_shard`,
+            `blink`,
+            `assault`,
           ],
           situational: [
-            `solar_crest`,
-            `blink`,
-            `cyclone`,
-            `force_staff`,
-            `pipe`,
-            `guardian_greaves`,
+            `orb_of_venom`,
+			`black_king_bar`,
+            `glimmer_cape`,
+            `wind_waker`,
+            `crimson_guard`,
+            `lotus_orb`,
             `spirit_vessel`,
             `heavens_halberd`,
             `travel_boots`,
@@ -4445,21 +4453,21 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           core: [
             `arcane_boots`,
             `holy_locket`,
-            `tranquil_boots`,
+            `guardian_greaves`,
             `ultimate_scepter`,
-            `aghanims_shard`,
+            `pipe`,
           ],
           neutral: [
-            `lance_of_pursuit`,
-            `broom_handle`,
+            `faded_broach`,
+            `mysterious_hat`,
             `bullwhip`,
-            "philosophers_stone",
-            "quickening_charm",
+            `dragon_scale`,
+            `defiant_shell`,
             `ogre_seal_totem`,
             `havoc_hammer`,
             `ascetic_cap`,
             `fallen_sky`,
-            `demonicon`,
+            `giants_ring`,
           ],
         },
         item_tooltips: {
@@ -4467,7 +4475,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           holy_locket:
             "A core item that boosts the healing coming for Solar Guardian and other sources.",
           guardian_greaves:
-            "If you need dispel. Fits well with the healing theme of this hero.",
+            `A core item that provides sustain and auras for your team.`,
           ultimate_scepter:
             "A core item that provides even more healing but also evasion to allies under effect of Solar Guardian.",
           aghanims_shard: `A late game pick up to help you transition into a damage dealer.`,
@@ -4483,17 +4491,17 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         abilities: [
           `dawnbreaker_celestial_hammer`, // 1
           `dawnbreaker_fire_wreath`, // 2
-          "dawnbreaker_celestial_hammer", // 3
-          "dawnbreaker_luminosity", // 4   equals to `starbreaker`
+          `dawnbreaker_luminosity`, // 3
+          `dawnbreaker_celestial_hammer`, // 4   equals to `starbreaker`
           `dawnbreaker_celestial_hammer`, // 5
           "dawnbreaker_solar_guardian", // 6
           `dawnbreaker_celestial_hammer`, // 7
-          "dawnbreaker_fire_wreath", // 8
+          `dawnbreaker_luminosity`, // 8
           `dawnbreaker_fire_wreath`, // 9
           `dawnbreaker_fire_wreath`, // 10
-          `special_bonus_unique_dawnbreaker_fire_wreath_swipe`, // 11
+          `dawnbreaker_fire_wreath`, // 11
           "dawnbreaker_solar_guardian", // 12
-          "dawnbreaker_luminosity", // 13
+          `special_bonus_unique_dawnbreaker_fire_wreath_swipe`, // 13
           "dawnbreaker_luminosity", // 14
           "special_bonus_unique_dawnbreaker_luminosity_crit", // 15
           "dawnbreaker_luminosity", // 16
@@ -4524,39 +4532,43 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `infused_raindrop`,
           ],
           mid_game: [
-            `echo_sabre`,
-            `aghanims_shard`,
-            `desolator`,
+            `desolater`,
             `black_king_bar`,
-            `basher`,
+            `aghanims_shard`,
             `blink`,
+			`basher`,
           ],
-          late_game: [`assault`, `satanic`, `overwhelming_blink`],
+          late_game: [`assault`, `harpoon`, `greater_crit`, `satanic`],
           situational: [
             `armlet`,
             `orb_of_corrosion`,
-            `orchid`,
+			`echo_sabre`,
+            `bloodthorn`,
+			`crimson_guard`,
             `ultimate_scepter`,
             `pipe`,
+			`guardian_greaves`,
             `heavens_halberd`,
             `spirit_vessel`,
             `silver_edge`,
+			`abyssal_blade`,
+			`overwhelming_blink`,
             `travel_boots`,
           ],
           core: [
             `phase_boots`,
             `soul_ring`,
-            `echo_sabre`,
-            `aghanims_shard`,
-            `desolator`,
+            `desolater`,
             `black_king_bar`,
+            `aghanims_shard`,
             `basher`,
+            `assault`,
           ],
           neutral: [
-            `broom_handle`,
-            `occult_bracelet`,
-            `vambrace`,
-            //`dagger_of_ristul`,
+            `duelist_gloves`,
+            `faded_broach`,
+            `orb_of_destruction`,
+            `dragon_scale`,
             "cloak_of_flames",
             `ogre_seal_totem`,
             `havoc_hammer`,
@@ -4566,16 +4578,17 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           ],
         },
         ability_tooltips: {
-          dawnbreaker_luminosity: `If you cannot play for a kill, you can put first point in this spell at level 3 already for easier lasthitting and some sustain.`,
+          dawnbreaker_celestial_hammer: `If you can play for a kill, you can put a second point in this spell on level 3 and get Luminosity on Level 4.`,
         },
         item_tooltips: {
           orb_of_corrosion: `Lets you apply more pressure in the lane.`,
           phase_boots: "A core item that allows you to gap-close faster.",
           soul_ring: "A core item that helps with mana sustain.",
           echo_sabre:
-            "A core item that allows you to deliver damage quickly. Can be disassembled and Ogre Axe used for quicker Black King Bar timing. You can assemble Echo Sabre back again.",
-          orchid:
-            "Allows you to land solo kills. You can get an Oblivion Staff from Echo Sabre by disassembling it.",
+            `A core item that boosts your damage output and tankiness. Choose between this item and Desolator based on whether you need more tankiness or damage. Builds into Harpoon in the late game.`,
+		  desolater: `A core item that gives you massive burst potential with Starbreaker. Choose between this item and Echo Sabre based on whether you need more damage or some tankiness.`,
+          bloodthorn:
+            `Allows you to land solo kills while disabling enemies with a silence.`,
           heavens_halberd: "Especially good against ranged right-clikers.",
           aghanims_shard:
             "A core item that grants allows you to become spell-immune during Starbreaker.",
@@ -6366,7 +6379,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           core: [`force_staff`, `boots_of_bearing`, `holy_locket`, `hurricane_pike`, `ultimate_scepter`],
           neutral: [
             "trusty_shovel",
-            `faded_broach`,
+            `unstable_wand`,
             `grove_bow`,
             `orb_of_destruction`,
             `dandelion_amulet`,
@@ -6439,7 +6452,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Enigma: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -6459,13 +6472,13 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "enigma_demonic_conversion", // 7
           `enigma_malefice`, // 8
           `enigma_malefice`, // 9
-          `special_bonus_unique_enigma_6`, // 10
+          `special_bonus_unique_enigma_4`, // 10
           `enigma_midnight_pulse`, // 11
           `enigma_black_hole`, // 12
           `enigma_midnight_pulse`, // 13
           `enigma_midnight_pulse`, // 14
-          `enigma_midnight_pulse`, // 15
-          `special_bonus_hp_250`, // 16
+          `special_bonus_hp_250`, // 15
+          `enigma_midnight_pulse`, // 16
           "special_bonus_attributes", // 17
           "enigma_black_hole", // 18
           "special_bonus_attributes", // 19
@@ -6479,41 +6492,43 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         items: {
           starting: [
             `tango`,
-            `tango`,
-            "mantle",
-            "circlet",
-            `clarity`,
+            `sobi_mask`,
+            `circlet`,
+            `branches`,
+            `branches`,
             `branches`,
             `ward_observer`,
           ],
           early_game: [
             `null_talisman`,
-            `null_talisman`,
             `arcane_boots`,
             `magic_wand`,
             `wind_lace`,
           ],
-          mid_game: ["blink", "black_king_bar", `sphere`, `refresher`],
+          mid_game: [`guardian_greaves`, `blink`, `black_king_bar`, `aghanims_shard`],
           late_game: [
-            `octarine_core`,
+            `refresher`,
             `ultimate_scepter`,
-            `aghanims_shard`,
+            `octarine_core`,
             `aeon_disk`,
           ],
           situational: [
             `hand_of_midas`,
             `soul_ring`,
+			`sphere`,
             `invis_sword`,
             `helm_of_the_overlord`,
             `shivas_guard`,
-            `arcane_blink`,
+            `pipe`,
+			`aether_lens`,
+			`force_staff`,
             `travel_boots`,
           ],
           core: [
             `arcane_boots`,
             `blink`,
             `black_king_bar`,
-            `sphere`,
+            `aghanims_shard`,
             `refresher`,
           ],
           neutral: [
@@ -6546,15 +6561,15 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "enigma_malefice", // 4
           "enigma_demonic_conversion", // 5
           "enigma_black_hole", // 6
-          "enigma_demonic_conversion", // 7
-          "enigma_midnight_pulse", // 8
-          `enigma_malefice`, // 9
+          `enigma_malefice`, // 7
+          `enigma_malefice`, // 8
+          `enigma_midnight_pulse`, // 9
           `special_bonus_unique_enigma_6`, // 10
-          `enigma_malefice`, // 11
+          `enigma_demonic_conversion`, // 11
           `enigma_black_hole`, // 12
           `enigma_midnight_pulse`, // 13
           `enigma_midnight_pulse`, // 14
-          `special_bonus_unique_enigma_5`, // 15
+          `special_bonus_hp_250`, // 15
           `enigma_midnight_pulse`, // 16
           "special_bonus_attributes", // 17
           "enigma_black_hole", // 18
@@ -6569,16 +6584,15 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         items: {
           starting: [
             `tango`,
-            `flask`,
-            `sobi_mask`,
+            `tango`,
+            `blood_grenade`,
             `clarity`,
-            `clarity`,
+            `branches`,
             `enchanted_mango`,
             `ward_observer`,
-            `ward_sentry`,
           ],
           early_game: [
-            `null_talisman`,
+            `ward_sentry`,
             `ring_of_basilius`,
             "arcane_boots",
             "magic_wand",
@@ -6588,20 +6602,20 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "blink",
             "black_king_bar",
             "aghanims_shard",
-            "aether_lens",
+            `guardian_greaves`,
           ],
           late_game: [
             `refresher`,
-            `sphere`,
-            `octarine_core`,
             `ultimate_scepter`,
+            `octarine_core`,
             `aeon_disk`,
           ],
           situational: [
-            `ring_of_basilius`,
+            `sphere`,
             `invis_sword`,
             `shivas_guard`,
-            `arcane_blink`,
+            `pipe`,
+			`force_staff`,
             `travel_boots`,
           ],
           core: [
@@ -6610,7 +6624,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `black_king_bar`,
             `aghanims_shard`,
             `refresher`,
-            `sphere`,
+            `aeon_disk`,
           ],
           neutral: [
             `pogo_stick`,
@@ -9888,7 +9902,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Lion: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -9908,10 +9922,10 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "lion_impale", // 7
           `lion_mana_drain`, // 8
           "lion_voodoo", // 9
-          "lion_voodoo", // 10
+          `special_bonus_unique_lion_3`, // 10
           `lion_voodoo`, // 11
           "lion_finger_of_death", // 12
-          `special_bonus_unique_lion_3`, // 13
+          `lion_voodoo`, // 13
           "lion_mana_drain", // 14
           `special_bonus_unique_lion_11`, // 15
           "lion_mana_drain", // 16
@@ -9926,7 +9940,16 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "special_bonus_unique_lion_4", // 25
         ],
         items: {
-          starting: ["tango", "boots", "ward_observer"],
+          starting: [
+			`tango`,
+            `tango`,
+            `blood_grenade`,
+            `enchanted_mango`,
+			`circlet`,
+			`branches`,
+			`branches`,
+            `ward_observer`,
+		  ],
           early_game: [
             `ward_sentry`,
             "tranquil_boots",
@@ -9936,40 +9959,39 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           ],
           mid_game: [
             "blink",
-            "aether_lens",
-            "aghanims_shard",
-            "force_staff",
-            "glimmer_cape",
+            `force_staff`,
+			`aether_lens`,
+            `aghanims_shard`,
           ],
-          late_game: ["aeon_disk", "ultimate_scepter", "octarine_core"],
+          late_game: [`ethereal_blade`, `ultimate_scepter`, `aeon_disk`, `octarine_core`],
           situational: [
             `ghost`,
-            `cyclone`,
-            "lotus_orb",
-            `ethereal_blade`,
+            `boots_of_bearing`,
+            `lotus_orb`,
             `wind_waker`,
             `black_king_bar`,
             `travel_boots`,
           ],
-          core: ["tranquil_boots", "blink", `aether_lens`, "aghanims_shard"],
+          core: [`tranquil_boots`, `blink`, `force_staff`, `aether_lens`, `aghanims_shard`],
           neutral: [
             "pogo_stick",
-            `trusty_shovel`,
+            `mysterious_hat`,
             "philosophers_stone",
-            `bullwhip`,
+            `grove_bow`,
             "psychic_headband",
             `ceremonial_robe`,
             "timeless_relic",
             "spy_gadget",
             "seer_stone",
-            "book_of_shadows",
+            `fallen_sky`,
           ],
         },
       },
     ],
     ability_tooltips: {
       lion_voodoo:
-        "You can skill this spell on level 2 or 3 already if you can score an early kill.",
+        `You can skill this spell on level 2 or 3 already if you can score an early kill.`,
+	  special_bonus_unique_lion_10: `Take this Mana restore talent over the suggested one when playing with mana dependent cores such as Storm Spirit or Leshrac.`,
     },
     item_tooltips: {
       ward_sentry: "To block or unblock the pull camp.",
@@ -11775,7 +11797,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Mirana: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -11814,49 +11836,50 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         ],
         items: {
           starting: [
-            "tango",
+            `tango`,
+			`tango`,
             "circlet",
-            "flask",
-            "faerie_fire",
+            `blood_grenade`,
             `branches`,
             `branches`,
             `clarity`,
-            "ward_observer",
+            `ward_observer`,
+			`ward_sentry`,
           ],
           early_game: [
-            `ward_sentry`,
             "urn_of_shadows",
-            `boots`,
+            `arcane_boots`,
             "magic_wand",
             `infused_raindrop`,
           ],
-          mid_game: ["cyclone", "force_staff", `spirit_vessel`],
+          mid_game: [`guardian_greaves`, `rod_of_atos`, `cyclone`],
           late_game: [
-            "ethereal_blade",
+            `force_staff`,
+			`gungir`,
             "ultimate_scepter",
-            "sheepstick",
-            "octarine_core",
+            `sheepstick`,
           ],
           situational: [
-            `arcane_boots`,
+            `spirit_vessel`,
             `heavens_halberd`,
             `pipe`,
             `orchid`,
             `blink`,
-            `guardian_greaves`,
+            `ethereal_blade`,
+			`aghanims_shard`,
             "lotus_orb",
             `wind_waker`,
             `travel_boots`,
           ],
-          core: [`boots`, `cyclone`, `spirit_vessel`, `force_staff`],
+          core: [`arcane_boots`, `urn_of_shadows`, `guardian_greaves`, `rod_of_atos`, `cyclone`],
           neutral: [
-            "arcane_ring",
-            `trusty_shovel`,
+            `faded_broach`,
+            `mysterious_hat`,
             "philosophers_stone",
-            "bullwhip",
+            `pupils_gift`,
             "quickening_charm",
-            "enchanted_quiver",
-            `spy_gadget`,
+            `ceremonial_robe`,
+            `timeless_relic`,
             `ninja_gear`,
             "force_field",
             `demonicon`,
@@ -11875,11 +11898,12 @@ export const heroBuilds: { [key: string]: HeroContent } = {
       infused_raindrop: "Against magical burst.",
       urn_of_shadows:
         "A core item that provides you with good stats. Try to rush it to have a good lane and then snowball off some kills.",
-      arcane_boots: `You can make early Arcane Boots if you plan to get Guardian Greaves or Lotus Orb at some point in the game.`,
+      arcane_boots: `You can make early Arcane Boots which build into Guardian Greaves later in the game.`,
       spirit_vessel: "Against heavy-healing lineup.",
       cyclone:
         "A core item that allows you to setup Sacred Arrow. Goes well with Blink Dagger.",
-      blink: `A late game pick up that lets you get in and out of fights without committing too many leap charges.`,
+      rod_of_atos: `A long range set up item for your arrow similar to Euls. Lets you land arrows without having to Leap in.`,
+	  blink: `A late game pick up that lets you get in and out of fights without committing too many Leap charges.`,
       lotus_orb: "For reflect, dispel and armor.",
     },
     combo: [
@@ -14692,7 +14716,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Pangolier: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.neutral,
     builds: [
@@ -14717,12 +14741,12 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "pangolier_gyroshell", // 12
           "pangolier_lucky_shot", // 13
           "pangolier_lucky_shot", // 14
-          "special_bonus_unique_pangolier_6", // 15
+          `special_bonus_unique_pangolier_2`, // 15
           "pangolier_lucky_shot", // 16
           "special_bonus_attributes", // 17
           "pangolier_gyroshell", // 18
           "special_bonus_attributes", // 19
-          `special_bonus_unique_pangolier_shield_crash_herostacks`, // 20
+          `special_bonus_unique_pangolier_3`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
@@ -14733,7 +14757,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           starting: [
             "tango",
             "quelling_blade",
-            `slippers`,
+            `circlet`,
             "circlet",
             `branches`,
             `branches`,
@@ -14746,53 +14770,55 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `wraith_band`,
             `infused_raindrop`,
           ],
-          mid_game: ["blink", `diffusal_blade`, "aghanims_shard", "basher"],
+          mid_game: [`guardian_greaves`, `blink`, `aghanims_shard`, `pipe`],
           late_game: [
+            `diffusal_blade`,
             `monkey_king_bar`,
-            "ultimate_scepter",
-            `octarine_core`,
+            `ultimate_scepter`,
             `overwhelming_blink`,
             `abyssal_blade`,
           ],
           situational: [
             `power_treads`,
-            `cyclone`,
             `spirit_vessel`,
-            `maelstrom`,
+			`octarine_core`,
+            `gungir`,
             `lotus_orb`,
             `aeon_disk`,
             `sphere`,
+			`octarine_core`,
             `black_king_bar`,
             `arcane_blink`,
             `wind_waker`,
+			`crimson_guard`,
             `travel_boots`,
           ],
           core: [
-            "orb_of_corrosion",
-            "arcane_boots",
+            `guardian_greaves`,
             "blink",
+            `aghanims_shard`,
+            `pipe`,
             `diffusal_blade`,
-            "aghanims_shard",
-            "basher",
+			`ultimate_scepter`,
           ],
           neutral: [
-            "arcane_ring",
-            `broom_handle`,
-            "dragon_scale",
-            `bullwhip`,
-            "quickening_charm",
+            `lance_of_pursuit`,
+            `unstable_wand`,
+            `pupils_gift`,
+            `orb_of_destruction`,
+            `ogre_seal_totem`,
             `cloak_of_flames`,
-            `havoc_hammer`,
-            `spell_prism`,
-            "fallen_sky",
+            `mind_breaker`,
+            `penta_edged_sword`,
+            `desolator_2`,
             `mirror_shield`,
           ],
         },
         item_tooltips: {
           spirit_vessel: "Against heavy-healing lineup.",
-          maelstrom:
+          gungir:
             "Great against illusion based heroes especially if paired with Aghanim`s Scepter later on.",
-          cyclone: `A situational item that allows you to stop during Rolling Thunder and chain stun an enemy. Can be used as a dispel, namely against silences and roots.`,
+          wind_waker: `A situational item that allows you to stop during Rolling Thunder and chain stun an enemy. Can be used as a dispel, namely against silences and roots.`,
           lotus_orb: "For reflect, dispel and armor.",
         },
       },
@@ -14806,14 +14832,14 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "pangolier_shield_crash", // 1
           "pangolier_swashbuckle", // 2
           "pangolier_shield_crash", // 3
-          "pangolier_lucky_shot", // 4
+          `pangolier_swashbuckle`, // 4
           "pangolier_shield_crash", // 5
           "pangolier_gyroshell", // 6
           "pangolier_shield_crash", // 7
           "pangolier_swashbuckle", // 8
           "pangolier_swashbuckle", // 9
-          `pangolier_swashbuckle`, // 10
-          `special_bonus_unique_pangolier`, // 11
+          `special_bonus_unique_pangolier`, // 10
+          `pangolier_lucky_shot`, // 11
           "pangolier_gyroshell", // 12
           "pangolier_lucky_shot", // 13
           "pangolier_lucky_shot", // 14
@@ -14832,9 +14858,12 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         items: {
           starting: [
             `tango`,
-            `orb_of_venom`,
-            `flask`,
-            `enchanted_mango`,
+            `tango`,
+            `blood_grenade`,
+            `circlet`,
+			`branches`,
+			`branches`,
+			`branches`,
             `ward_sentry`,
             `ward_observer`,
           ],
@@ -14842,53 +14871,54 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "arcane_boots",
             "magic_wand",
             `urn_of_shadows`,
+			`wind_lace`,
             `infused_raindrop`,
           ],
-          mid_game: ["blink", "aghanims_shard", "cyclone", `lotus_orb`],
+          mid_game: [`guardian_greaves`, `pavise`, `blink`, `aghanims_shard`],
           late_game: [
-            "aeon_disk",
-            "octarine_core",
-            `overwhelming_blink`,
-            `monkey_king_bar`,
-            "ultimate_scepter",
+            `pipe`,
+            `force_staff`,
+            `gungir`,
+            `aeon_disk`,
           ],
           situational: [
             `orb_of_corrosion`,
             `spirit_vessel`,
-            `guardian_greaves`,
-            `pipe`,
+            `crimson_guard`,
+            `vladmir`,
             `heavens_halberd`,
-            `arcane_blink`,
+            `solar_crest`,
             `wind_waker`,
-            `ethereal_blade`,
-            `sphere`,
-            `basher`,
+            `lotus_orb`,
+            `octarine_core`,
+            `overwhelming_blink`,
             `travel_boots`,
           ],
           core: [
-            "arcane_boots",
+            `guardian_greaves`,
             "blink",
             "aghanims_shard",
             "cyclone",
-            `aeon_disk`,
+            `pipe`,
+			`force_staff`,
           ],
           neutral: [
             `arcane_ring`,
-            `trusty_shovel`,
-            `dragon_scale`,
+            `faded_broach`,
+            `pupils_gift`,
             `bullwhip`,
-            `quickening_charm`,
+            `ogre_seal_totem`,
             `ceremonial_robe`,
             `havoc_hammer`,
-            `spell_prism`,
+            `timeless_relic`,
             `fallen_sky`,
-            `mirror_shield`,
+            `force_field`,
           ],
         },
         item_tooltips: {
           spirit_vessel: "Against heavy-healing lineup.",
-          cyclone:
-            "A core item that allows you to stop during Rolling Thunder and chain stun an enemy. Can be used as a dispel, namely against silences and roots.",
+          wind_waker:
+            `A situational item that allows you to stop during Rolling Thunder and chain stun an enemy. Can be used as a dispel, namely against silences and roots.`,
           lotus_orb: "For reflect, dispel and armor.",
         },
       },
@@ -14902,11 +14932,11 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "pangolier_shield_crash", // 1
           "pangolier_swashbuckle", // 2
           `pangolier_swashbuckle`, // 3
-          `pangolier_lucky_shot`, // 4
+          `pangolier_shield_crash`, // 4
           `pangolier_swashbuckle`, // 5
           "pangolier_gyroshell", // 6
           `pangolier_swashbuckle`, // 7
-          `pangolier_shield_crash`, // 8
+          `pangolier_lucky_shot`, // 8
           `pangolier_shield_crash`, // 9
           `special_bonus_unique_pangolier`, // 10
           `pangolier_shield_crash`, // 11
@@ -14923,7 +14953,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          "special_bonus_unique_pangolier_4", // 25
+          `special_bonus_unique_pangolier_5`, // 25
         ],
         items: {
           starting: [
@@ -14931,72 +14961,72 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "quelling_blade",
             `branches`,
             `branches`,
+			`branches`,
             `faerie_fire`,
             `ward_observer`,
           ],
           early_game: [
             "bottle",
             "orb_of_corrosion",
-            "arcane_boots",
+            `power_treads`,
             `magic_wand`,
             `infused_raindrop`,
           ],
           mid_game: [
             `diffusal_blade`,
-            "blink",
             "aghanims_shard",
-            "basher",
-            "ultimate_scepter",
+            `ultimate_scepter`,
+            `basher`,
+			`blink`,
           ],
           late_game: [
-            `monkey_king_bar`,
             `octarine_core`,
-            `overwhelming_blink`,
             `abyssal_blade`,
+            `monkey_king_bar`,
+            `overwhelming_blink`,
           ],
           situational: [
             `spirit_vessel`,
-            `power_treads`,
-            `echo_sabre`,
-            `maelstrom`,
+            `guardian_greaves`,
+            `harpoon`,
+            `gungir`,
             `bloodthorn`,
-            `cyclone`,
             `sphere`,
             `lotus_orb`,
             `black_king_bar`,
             `aeon_disk`,
             `wind_waker`,
+			`shivas_guard`,
             `travel_boots`,
           ],
           core: [
-            "bottle",
-            "orb_of_corrosion",
-            "arcane_boots",
+            `bottle`,
+            `power_treads`,
             `diffusal_blade`,
-            "blink",
-            "aghanims_shard",
+            `aghanims_shard`,
+            `ultimate_scepter`,
             "basher",
-            "ultimate_scepter",
+            `blink`,
           ],
           neutral: [
-            `occult_bracelet`,
-            `broom_handle`,
-            //`dagger_of_ristul`,
-            `bullwhip`,
-            `quickening_charm`,
-            `mind_breaker`,
+            `lance_of_pursuit`,
+            `unstable_wand`,
+            `pupils_gift`,
+            `orb_of_destruction`,
+            `titan_sliver`,
+            `ogre_seal_totem`,
             `penta_edged_sword`,
-            `spell_prism`,
-            `fallen_sky`,
+            `mind_breaker`,
+            `desolator_2`,
             `mirror_shield`,
           ],
         },
         item_tooltips: {
           bottle:
             "A core item that provides you with sustain and allows you to gank with stored rune.",
-          maelstrom: `A situational item against illusion and summons lineups.`,
+          gungir: `A situational item against illusion and summons lineups.`,
           diffusal_blade: `A core item that improves your damage and kill threat on the map with Swashbuckle.`,
-          cyclone:
+          wind_waker:
             "Allows you to stop during Rolling Thunder and chain stun an enemy. Can be used as a dispel, namely against silences and roots.",
           black_king_bar:
             "Since this build is not all about Rolling Thunder you might need this item to be able to right-click or Swashbuckle the opponents in the middle of the fight.",
@@ -15008,10 +15038,10 @@ export const heroBuilds: { [key: string]: HeroContent } = {
     ability_tooltips: {},
     item_tooltips: {
       magic_wand: `Start with magic stick if you expect high frequency of spells being used on the lane.`,
-      orb_of_corrosion: "A core item that gets applied by Swashbuckle.",
+      orb_of_corrosion: `A situational item that gets applied by Swashbuckle.`,
       infused_raindrop: "Against magical burst.",
       arcane_boots:
-        "A core boots upgrade that helps with mana sustain. Can be disassembled later on.",
+        `A situational boots upgrade that builds into Guardian Greaves.`,
       blink:
         "A core item that allows you to jump on the opponents while Rolling Thunder is active.",
       aghanims_shard:
@@ -15024,8 +15054,8 @@ export const heroBuilds: { [key: string]: HeroContent } = {
       `pangolier_swashbuckle`,
       `pangolier_gyroshell`,
       `blink`,
-      `urn_of_shadows`,
       `pangolier_shield_crash`,
+	  `pangolier_rollup`,
       `pangolier_swashbuckle`,
     ],
     counter_items: {
@@ -15419,7 +15449,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
 
   // YoonA plays hero
   Phoenix: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -15459,47 +15489,53 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         items: {
           starting: [
             "tango",
-            "flask",
-            `faerie_fire`,
+            `tango`,
+            `blood_grenade`,
             `branches`,
+			`branches`,
             `branches`,
             "circlet",
             `ward_observer`,
             `ward_sentry`,
           ],
           early_game: [
-            "urn_of_shadows",
-            "tranquil_boots",
-            "magic_wand",
+            `tranquil_boots`,
+            `magic_wand`,
+            `urn_of_shadows`,
             "infused_raindrop",
           ],
-          mid_game: [`aghanims_shard`, `shivas_guard`],
-          late_game: ["refresher", "aeon_disk", "sheepstick", "travel_boots"],
+          mid_game: [`aghanims_shard`, `boots_of_bearing`, `shivas_guard`],
+          late_game: [`refresher`, `aeon_disk`, `sheepstick`, `octarine_core`],
           situational: [
-            "spirit_vessel",
+            `guardian_greaves`,
             "lotus_orb",
             `holy_locket`,
+			`spirit_vessel`,
+			`wind_waker`,
+			`meteor_hammer`,
+			`glimmer_cape`,
             `ethereal_blade`,
             "force_staff",
             "heavens_halberd",
             "pipe",
             `ultimate_scepter`,
             "radiance",
-            "kaya_and_sange",
+            `travel_boots`,
           ],
           core: [
             "tranquil_boots",
             "aghanims_shard",
-            `shivas_guard`,
+            `boots_of_bearing`,
+			`shivas_guard`,
             `refresher`,
           ],
           neutral: [
-            "trusty_shovel",
-            `seeds_of_serenity`,
+            `unstable_wand`,
+            `mysterious_hat`,
             "philosophers_stone",
-            //`nether_shawl`,
+            `pupils_gift`,
             "quickening_charm",
-            "ceremonial_robe",
+            `dandelion_amulet`,
             "spell_prism",
             "timeless_relic",
             "book_of_shadows",
@@ -15520,7 +15556,11 @@ export const heroBuilds: { [key: string]: HeroContent } = {
       tranquil_boots:
         "A core boots upgrade. Solves hp sustain and movement speed issues for the hero.",
       spirit_vessel: `Upgrade the Urn to Spirit Vessel early on against heavy-healing lineup.`,
-      holy_locket: `A situational item that signifcantly amplifies healing coming from Sunray. Provides you with a second source of burst healing when activating the item.`,
+      refresher: `An incredible late game pick up that massively improves your teamfight potential.`,
+	  shivas_guard: `A core item that improves your tankiness and increases the chances of your Supernova surviving by decreasing attack speed around you.`,
+	  wind_waker: `Gives you a dispel and allows you to move to safety with invulnerability.`,
+	  meteor_hammer: `A combination item that goes with Euls to cyclone and hammer an enemy hero. Also provides tower push.`,
+	  holy_locket: `A situational item that signifcantly amplifies healing coming from Sunray. Provides you with a second source of burst healing when activating the item.`,
       aghanims_shard:
         "A core upgrade that allows you to use Sunray during Supernova. Ideally, use the Sunray before you activate Supernova so you have another Sunray once the egg explodes.",
       lotus_orb: "For reflect, dispel and armor.",
@@ -16467,6 +16507,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           ],
           mid_game: [
             `force_staff`,
+			`pavise`,
 			`aether_lens`,
             `tranquil_boots`,
             `glimmer_cape`,
@@ -18644,6 +18685,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `arcane_boots`,
             `force_staff`,
             `aether_lens`,
+			`phylactery`,
             `aghanims_shard`,
           ],
           late_game: [
@@ -21463,7 +21505,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Tinker: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -21488,7 +21530,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "tinker_keen_teleport", // 12
           "tinker_defense_matrix", // 13
           "tinker_defense_matrix", // 14
-          `special_bonus_unique_tinker_6`, // 15
+          `special_bonus_unique_tinker_7`, // 15
           "tinker_defense_matrix", // 16
           "special_bonus_attributes", // 17
           "tinker_keen_teleport", // 18
@@ -21506,23 +21548,23 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "faerie_fire",
             `branches`,
             `branches`,
-            `mantle`,
+            `branches`,
             "ward_observer",
           ],
-          early_game: ["bottle", "soul_ring", "blink", "null_talisman"],
+          early_game: [`bottle`, `soul_ring`, `blink`],
           mid_game: [
             `shivas_guard`,
+            `black_king_bar`,
             `overwhelming_blink`,
-            `ethereal_blade`,
-            `ultimate_scepter`,
+            `sheepstick`,
           ],
-          late_game: [`sheepstick`, `black_king_bar`, `dagon`],
+          late_game: [`ethereal_blade`, `ultimate_scepter`, `bloodstone`, `wind_waker`],
           situational: [
             `magic_wand`,
             `aether_lens`,
             `force_staff`,
             `kaya_and_sange`,
-            `wind_waker`,
+            `dagon_5`,
             `aeon_disk`,
             `aghanims_shard`,
           ],
@@ -21531,26 +21573,28 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "soul_ring",
             `blink`,
             `shivas_guard`,
-            `overwhelming_blink`,
-            `ultimate_scepter`,
             `black_king_bar`,
+            `overwhelming_blink`,
+            `sheepstick`,
           ],
           neutral: [
             "mysterious_hat",
             `pogo_stick`,
             "philosophers_stone",
-            //`nether_shawl`,
+            `vambrace`,
             "psychic_headband",
             "ceremonial_robe",
             "timeless_relic",
-            "stormcrafter",
+            `spy_gadget`,
             "seer_stone",
             "mirror_shield",
           ],
         },
       },
     ],
-    ability_tooltips: {},
+    ability_tooltips: {
+		special_bonus_unique_tinker_3: `Take this level 25 talent over the suggested one if the enemy team has channeling spells you can interrupt, such as Black Hole.`,
+	},
     item_tooltips: {
       bottle:
         "A core item that provides you with sustain and allows you to fight with stored rune.",
@@ -23665,7 +23709,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Viper: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.magical,
     builds: [
@@ -23679,14 +23723,14 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "viper_poison_attack", // 1
           "viper_corrosive_skin", // 2
           "viper_poison_attack", // 3
-          "viper_nethertoxin", // 4
+          `viper_corrosive_skin`, // 4
           "viper_poison_attack", // 5
           "viper_viper_strike", // 6
           `viper_poison_attack`, // 7
-          `viper_corrosive_skin`, // 8
+          `viper_nethertoxin`, // 8
           "viper_corrosive_skin", // 9
-          `special_bonus_unique_viper_4`, // 10
-          "viper_corrosive_skin", // 11
+          `viper_corrosive_skin`, // 10
+          `special_bonus_unique_viper_1`, // 11
           "viper_viper_strike", // 12
           `viper_nethertoxin`, // 13
           "viper_nethertoxin", // 14
@@ -23700,70 +23744,72 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          `special_bonus_unique_viper_8`, // 25
+          `special_bonus_unique_viper_5`, // 25
         ],
         items: {
           starting: [
             `tango`,
             `circlet`,
-            `slippers`,
+            `circlet`,
             `enchanted_mango`,
             `branches`,
             `branches`,
             `ward_observer`,
           ],
           early_game: [
-            "urn_of_shadows",
-            `power_treads`,
+            `boots`,
             "wind_lace",
             "magic_wand",
-            "wraith_band",
+            `wraith_band`,
+			`wraith_band`,
+			`cloak`,
           ],
           mid_game: [
-            "dragon_lance",
-            `black_king_bar`,
-            "aghanims_shard",
-            `hurricane_pike`,
+            `travel_boots`,
+            `ultimate_scepter`,
+            `bloodstone`,
+            `pipe`,
           ],
-          late_game: [`ultimate_scepter`, `assault`, `butterfly`],
+          late_game: [`kaya_and_sange`, `black_king_bar`, `aghanims_shard`, `assault`],
           situational: [
             `ring_of_basilius`,
-            `hood_of_defiance`,
             "spirit_vessel",
-            `manta`,
+            `eternal_shroud`,
+			`manta`,
             `blink`,
-            `pipe`,
+            `hurricane_pike`,
             `skadi`,
             `gungir`,
-            `monkey_king_bar`,
+            `lotus_orb`,
             `aeon_disk`,
-            `swift_blink`,
-            `travel_boots`,
+            `heavens_halberd`,
+			`sheepstick`,
+            `travel_boots_2`,
           ],
           core: [
-            "urn_of_shadows",
-            "power_treads",
-            "dragon_lance",
+            `travel_boots`,
+			`ultimate_scepter`,
+            `bloodstone`,
+            `pipe`,
+            `kaya_and_sange`,
             `black_king_bar`,
-            `aghanims_shard`,
-            `assault`,
           ],
           neutral: [
-            `lance_of_pursuit`,
-            `occult_bracelet`,
+            `mysterious_hat`,
+            `faded_broach`,
             "grove_bow",
-            `bullwhip`,
+            `vampire_fangs`,
             "enchanted_quiver",
-            `elven_tunic`,
+            `paladin_sword`,
             `trickster_cloak`,
-            //`flicker`, Removed in 7.33
-            `pirate_hat`,
+            `mind_breaker`,
+            `fallen_sky`,
             `mirror_shield`,
           ],
         },
         item_tooltips: {
-          urn_of_shadows:
-            "A core item that allows you to snowball off of first kill. Provides you with useful stats, namely mana regeneration.",
+          /* urn_of_shadows:
+            "A core item that allows you to snowball off of first kill. Provides you with useful stats, namely mana regeneration.", */
           spirit_vessel: "Against heavy-healing lineup.",
         },
       },
@@ -23806,7 +23852,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             "faerie_fire",
             `branches`,
             `branches`,
-            `circlet`,
+            `branches`,
             `ward_observer`,
           ],
           early_game: [
@@ -23819,10 +23865,11 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           mid_game: [
             `travel_boots`,
             `ultimate_scepter`,
+			`cloak`,
             `bloodstone`,
             `eternal_shroud`,
           ],
-          late_game: [`kaya_and_sange`, `black_king_bar`, `aghanims_shard`],
+          late_game: [`kaya_and_sange`, `black_king_bar`, `aghanims_shard`, `assault`],
           situational: [
             `ring_of_basilius`,
             `spirit_vessel`,
@@ -23830,12 +23877,14 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `hurricane_pike`,
             `ethereal_blade`,
             `manta`,
+			`skadi`,
             `silver_edge`,
             `aeon_disk`,
             `sphere`,
             `lotus_orb`,
             `sheepstick`,
             `gungir`,
+			`travel_boots_2`,
           ],
           core: [
             "bottle",
@@ -23846,15 +23895,15 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `kaya_and_sange`,
           ],
           neutral: [
-            `lance_of_pursuit`,
-            `occult_bracelet`,
+            `mysterious_hat`,
+            `faded_broach`,
             `grove_bow`,
-            `bullwhip`,
-            `ogre_seal_totem`,
-            `quickening_charm`,
+            `vampire_fangs`,
+            `enchanted_quiver`,
+            `paladin_sword`,
             `trickster_cloak`,
-            //`flicker`,
-            `pirate_hat`,
+            `mind_breaker`,
+            `fallen_sky`,
             `mirror_shield`,
           ],
         },
@@ -23869,14 +23918,14 @@ export const heroBuilds: { [key: string]: HeroContent } = {
       },
     ],
     ability_tooltips: {
-      viper_nethertoxin: `At mid, consider putting a point in this spell at level 4 if the enemy midlaner has a passive you can break. You can also max out this spell in case you cannot fight the enemy mid with right clicks.`,
+      viper_nethertoxin: `Consider putting a point in this spell at level 4 if the enemy laner has a passive you can break. You can also max out this spell in case you cannot fight the enemy heroes with right clicks.`,
     },
     item_tooltips: {
       magic_wand: `Start with magic stick if you expect high frequency of spells being used on the lane.`,
-      power_treads:
-        "A core boots upgrade that provides significant attack speed increase and mana savings through toggling.",
+      /* power_treads:
+        "A core boots upgrade that provides significant attack speed increase and mana savings through toggling.", */
       wind_lace: `An early game movement speed boost for a slow hero like Viper.`,
-      dragon_lance: `A core item that improves attack range and tankiness.`,
+      // dragon_lance: `A core item that improves attack range and tankiness.`,
       black_king_bar:
         "A core item against disables, debuffs and as a dispel. Allows you to stand your ground and right-click.",
       skadi:
@@ -23884,12 +23933,12 @@ export const heroBuilds: { [key: string]: HeroContent } = {
       aghanims_shard:
         "A core upgrade of Poison Attack. Allows you to deal more damage to heroes and buildings.",
       blink: "For extra mobility.",
-      monkey_king_bar: "Against evasion and miss chance.",
+      // monkey_king_bar: "Against evasion and miss chance.",
       ethereal_blade: `A situational item that provides you with a boost to your damage with urn and Viper Strike. Also has defensive capabilities.`,
     },
     combo: [
-      `viper_viper_strike`,
-      `urn_of_shadows`,
+      `bloodstone`,
+	  `viper_viper_strike`,
       `viper_nethertoxin`,
       `viper_poison_attack`,
     ],
@@ -23937,7 +23986,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
   },
 
   Visage: {
-    gameplay_version: `7.32e`,
+    gameplay_version: `7.33b`,
     creator: ContentCreator.YoonA,
     damage_type: DamageType.neutral,
     builds: [
@@ -23957,7 +24006,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "visage_grave_chill", // 7
           `visage_gravekeepers_cloak`, // 8
           `visage_gravekeepers_cloak`, // 9
-          `special_bonus_unique_visage_7`, // 10
+          `special_bonus_unique_visage_8`, // 10
           `visage_gravekeepers_cloak`, // 11
           "visage_summon_familiars", // 12
           `visage_soul_assumption`, // 13
@@ -23980,59 +24029,61 @@ export const heroBuilds: { [key: string]: HeroContent } = {
             `branches`,
             "branches",
             "circlet",
-            "mantle",
+            `circlet`,
             `enchanted_mango`,
             `ward_observer`,
           ],
           early_game: [
-            "boots",
+            `tranquil_boots`,
             "magic_wand",
-            "null_talisman",
-            `vladmir`,
-            `infused_raindrop`,
+            `wind_lace`,
+            `blight_stone`,
+            `cloak`,
           ],
           mid_game: [
-            `wraith_pact`,
-            `tranquil_boots`,
-            `ultimate_scepter`,
+            `boots_of_bearing`,
+            `pipe`,
             `aghanims_shard`,
-            `ancient_janggo`,
+            `solar_crest`,
           ],
           late_game: [
-            `boots_of_bearing`,
-            `sheepstick`,
-            `bloodthorn`,
+            `vladmir`,
             `assault`,
+            `ultimate_scepter`,
+            `sheepstick`,
           ],
           situational: [
             `ring_of_basilius`,
-            `solar_crest`,
+			`null_talisman`,
+            `crimson_guard`,
             `rod_of_atos`,
-            `black_king_bar`,
-            `blink`,
+            `guardian_greaves`,
+            `bloodthorn`,
             `nullifier`,
             `aeon_disk`,
             `shivas_guard`,
             `travel_boots`,
           ],
           core: [
-            `boots`,
-            `wraith_pact`,
-            `ultimate_scepter`,
+            `tranquil_boots`,
+			`cloak`,
+            `boots_of_bearing`,
+            `pipe`,
             `aghanims_shard`,
-            `sheepstick`,
+            `vladmir`,
+			`sheepstick`,
           ],
           neutral: [
-            "arcane_ring",
-            `occult_bracelet`,
+            `lance_of_pursuit`,
+            `duelist_gloves`,
             "grove_bow",
-            `dragon_scale`,
-            `mind_breaker`,
+            `orb_of_destruction`,
+            `paladin_sword`,
             "enchanted_quiver",
-            //`heavy_blade`,
+            `mind_breaker`,
             `spy_gadget`,
             `desolator_2`,
-            `mirror_shield`,
+            `ex_machina`,
           ],
         },
         ability_tooltips: {},
@@ -24053,7 +24104,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           "visage_grave_chill", // 7
           `visage_gravekeepers_cloak`, // 8
           `visage_gravekeepers_cloak`, // 9
-          `special_bonus_unique_visage_7`, // 10
+          `special_bonus_unique_visage_8`, // 10
           `visage_soul_assumption`, // 11
           "visage_summon_familiars", // 12
           `visage_soul_assumption`, // 13
@@ -24074,54 +24125,55 @@ export const heroBuilds: { [key: string]: HeroContent } = {
           starting: [
             `tango`,
             `faerie_fire`,
-            `mantle`,
+            `circlet`,
+			`branches`,
             `branches`,
             `branches`,
             `ward_observer`,
           ],
-          early_game: [`boots`, "magic_wand", `null_talisman`],
+          early_game: [`tranquil_boots`, `magic_wand`, `falcon_blade`, `wind_lace`],
           mid_game: [
             `ultimate_scepter`,
-            `tranquil_boots`,
-            `ancient_janggo`,
+            `boots_of_bearing`,
             `aghanims_shard`,
+            `solar_crest`,
           ],
           late_game: [
-            `boots_of_bearing`,
             `sheepstick`,
-            `bloodthorn`,
             `assault`,
+            `bloodthorn`,
+            `nullifier`,
           ],
           situational: [
-            `ring_of_basilius`,
-            `rod_of_atos`,
-            `solar_crest`,
-            `wraith_pact`,
+            `blight_stone`,
+            `null_talisman`,
+            `vladmir`,
             `black_king_bar`,
-            `blink`,
-            `nullifier`,
+            `pipe`,
+            `crimson_guard`,
             `aeon_disk`,
             `shivas_guard`,
             `travel_boots`,
           ],
           core: [
-            `boots`,
+            `tranquil_boots`,
+			`falcon_blade`,
             `ultimate_scepter`,
             `boots_of_bearing`,
             `aghanims_shard`,
             `sheepstick`,
           ],
           neutral: [
-            "arcane_ring",
-            `occult_bracelet`,
-            "grove_bow",
-            `dragon_scale`,
+            `lance_of_pursuit`,
+            `duelist_gloves`,
+            `grove_bow`,
+            `orb_of_destruction`,
+            `paladin_sword`,
+            `enchanted_quiver`,
             `mind_breaker`,
-            "enchanted_quiver",
-            //`heavy_blade`,
-            "spell_prism",
+            `spy_gadget`,
             `desolator_2`,
-            `mirror_shield`,
+            `ex_machina`,
           ],
         },
       },
@@ -24129,7 +24181,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
     ability_tooltips: {},
     item_tooltips: {
       magic_wand: `Start with magic stick if you expect high frequency of spells being used on the lane.`,
-      boots: `A core item that can be upgraded to Tranquil Boots if you need sustain on the lane but usually you want to rush other core items.`,
+      // boots: `A core item that can be upgraded to Tranquil Boots if you need sustain on the lane but usually you want to rush other core items.`,
       infused_raindrop:
         "Against magical burst. It can save you a layer of Gravekeeper`s Cloak.",
       ultimate_scepter:
@@ -24140,7 +24192,7 @@ export const heroBuilds: { [key: string]: HeroContent } = {
         "A core item that allows you to instantly disable and then burst an opponent.",
       bloodthorn:
         "A core burst item. Goes well with Sycthe of Vyse as the affected opponent can`t dispel it for the duration of disable. Provides true strike.",
-      boots_of_bearing: `A late game upgrade for tranquil boots that benefit you and your Familiars.`,
+      boots_of_bearing: `A mid game upgrade for tranquil boots that benefit you and your Familiars.`,
       blink: `To reposition quickly.`,
     },
     combo: [

--- a/messages.ts
+++ b/messages.ts
@@ -829,9 +829,19 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/AncientAppartion_5_AghanimsShard",
     messageTime: 14 * 60 + 50,
     textMessage:
-      "Grab Aghanim's Shard at 15 minute mark as it allows you to clear waves, deal additional damage in the fights and cancel Blink Daggers.",
+      `Grab Aghanims Shard at 15 minute mark as it gives you a massive area of effect stun with Ice Blast.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
+  },
+  {
+    category: `OwnHero`,
+    hero: `Ancient Apparition`,
+    audioFile: `ownHero/AncientAppartion_6_Farming`,
+    messageTime: 16 * 60,
+    textMessage:
+      `When not much is happening on the map, use Ice Vortex to farm creep waves without showing yourself.`,
+    audience: [Audience.ALL],
+    image: { type: `ability`, name: `ancient_apparition_ice_vortex` },
   },
 
   {
@@ -2048,10 +2058,10 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
   {
     category: "OwnHero",
     hero: "Bristleback",
-    audioFile: "ownHero/Bristleback_4_StackCamps",
+    audioFile: `ownHero/Bristleback_4_Aggression`,
     messageTime: [6 * 60 + 45, 9 * 60 + 45, 12 * 60 + 45],
     textMessage:
-      "Bristleback is not the best at moving around and ganking. Rather, make the opponents come to you by being aggressive.",
+      `Apply aggression on the map as Bristleback by taking and defending towers, as well as rotating through portals.`,
     audience: [Audience.ALL],
   },
   {
@@ -3250,7 +3260,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 10 * 60 + 15,
     repeatTime: 8 * 60 + 15,
     textMessage:
-      "Play seperately from your team, push out lanes and mask team's smoke moves as you can connect to your team with ulty.",
+      `Play seperately from your team, push out lanes and mask team's smoke moves as you can connect to your team with ultimate.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "dawnbreaker_solar_guardian" },
   },
@@ -8525,6 +8535,24 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audience: [Audience.ALL],
     image: { type: "ability", name: "mirana_invis" },
   },
+  {
+    category: `OwnHero`,
+    hero: `Mirana`,
+    audioFile: `ownHero/Mirana_6_Neutrals`,
+    messageTime: 2 * 60,
+    textMessage: `Use Arrow to one shot hero controlled creeps. Especially useful against Chen, Enchantress, and Beastmaster.`,
+    audience: [Audience.ALL],
+    image: { type: `ability`, name: `mirana_arrow` },
+  },
+  {
+    category: `OwnHero`,
+    hero: `Mirana`,
+    audioFile: `ownHero/Mirana_7_Roaming`,
+    messageTime: 7 * 60 + 15,
+    textMessage: `Use the portals to roam around the map and set up kills with your lockdown.`,
+    audience: [Audience.ALL],
+    image: { type: `ability`, name: `mirana_arrow` },
+  },
 
   {
     category: "EnemyHero",
@@ -10328,7 +10356,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     hero: "Pangolier",
     audioFile: "ownHero/Pangolier_1_CrashLasthits",
     messageTime: 10,
-    textMessage: "Secure lasthits and damage the opponents at the same time with Shield Crash.",
+    textMessage: `Secure last hits and damage the opponents at the same time with Shield Crash.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "pangolier_shield_crash" },
   },
@@ -10395,7 +10423,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     hero: "Pangolier",
     audioFile: "ownHero/Pangolier_8_Roshan2",
     messageTime: 14 * 60 + 50,
-    textMessage: `Pick up Aghanims Shard at minute 15 as it allows you to escape roots and leashes, among other things.`,
+    textMessage: `Pick up Aghanims Shard at minute 15 as it gives you another survivability tool.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
   },
@@ -10449,7 +10477,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/Pangolier_6_SpellImmunityPiercing",
     messageTime: 12 * 60 + 20,
     textMessage:
-      "Spell immunity piercing spells and items are great at dealing with Pangolier's Rolling Thunder.",
+      `Spell immunity piercing stuns are great at dealing with Pangolier's Rolling Thunder.`,
     audience: [Audience.ALL],
   },
 
@@ -10460,6 +10488,15 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 12 * 60 + 30,
     textMessage:
       "Items and spells that can dispel enemies are great at removing Shield Crash buff from Pangolier.",
+    audience: [Audience.ALL],
+  },
+  {
+    category: `EnemyHero`,
+    hero: `Pangolier`,
+    audioFile: `enemyHero/Pangolier_8_CounterRoll`,
+    messageTime: 9 * 60 + 30,
+    textMessage:
+      `When Pangolier is about to hit you with Rolling Thunder, stand right at the edge of a high ground or low ground to avoid getting chain stunned.`,
     audience: [Audience.ALL],
   },
 
@@ -16219,8 +16256,8 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     hero: "Viper",
     audioFile: "ownHero/Viper_7_AghanimsShard_v2",
     messageTime: 14 * 60 + 50,
-    textMessage: `Pick up Aghanims Shard around minute 15 to further increase your dps and building damage.`,
-    audience: [Audience.ROLE_OFFLANE],
+    textMessage: `Pick up Aghanims Shard later on to further increase your dps and building damage.`,
+    audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
   },
   {
@@ -16229,17 +16266,17 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: `ownHero/Viper_8_Bloodstone`,
     messageTime: 18 * 60 + 50,
     textMessage: `Once you have Aghanims Scepter and Bloodstone, look to take fights and objectives around the map.`,
-    audience: [Audience.ROLE_CORE],
+    audience: [Audience.ALL],
     image: { type: `item`, name: `travel_boots` },
   },
   {
     category: `OwnHero`,
     hero: `Viper`,
-    audioFile: `ownHero/Viper_9_EternalShroud`,
+    audioFile: `ownHero/Viper_9_Aggression`,
     messageTime: 25 * 60,
-    textMessage: `Start running at enemy heroes with your Aghanims Scepter, Bloodstone and Eternal Shroud.`,
-    audience: [Audience.ROLE_CORE],
-    image: { type: `item`, name: `eternal_shroud` },
+    textMessage: `Start running at enemy heroes with your Aghanims Scepter, Bloodstone and Cloak.`,
+    audience: [Audience.ALL],
+    image: { type: `item`, name: `bloodstone` },
   },
 
   {
@@ -16291,7 +16328,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     hero: "Visage",
     audioFile: "ownHero/Visage_1_WeakLaner",
     messageTime: -30,
-    textMessage: "Visage is fairly weak until level 6. Play for lasthits and lane control.",
+    textMessage: `Visage is fairly weak until level 6. Play for last hits and lane control.`,
     audience: [Audience.ALL],
   },
   {


### PR DESCRIPTION
Updated the herobuilds, messages, disables, and dispellables for the following heroes:

Dawnbreaker (Support & Offlane)
Bristleback (Offlane)
Phoenix (Support)
Mirana (Support)
Ancient Apparition (Support)
Lion (Support)
Visage (Offlane & Mid)
Viper (Offlane & Mid)
Tinker (Mid)
Pangolier (Offlane, Mid & Support)
Enigma (Offlane & Support)