### PR TITLE
Updated Hero Guides

### DIFF
--- a/content/heroBuilds.ts
+++ b/content/heroBuilds.ts
@@ -236,6 +236,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40437,
         power_level: [1.6, 1.8, 1.9, 1.6],
+		facet: 2,
         abilities: [
           "abaddon_aphotic_shield", // 1
           "abaddon_frostmourne", // 2, equals to `curse of avernus`
@@ -345,6 +346,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40436,
         power_level: [1.6, 2.3, 2.2, 1.9],
+		facet: 2,
         abilities: [
           "abaddon_aphotic_shield", // 1
           "abaddon_frostmourne", // 2, equals to `curse of avernus`
@@ -6702,6 +6704,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40618,
         power_level: [1.5, 1.9, 2, 2.2],
+		facet: 1,
         abilities: [
           "wisp_tether", // 1
           "wisp_overcharge", // 2
@@ -6722,7 +6725,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 17
           "wisp_relocate", // 18
           "special_bonus_attributes", // 19
-          `special_bonus_unique_wisp_6`, // 20
+          `special_bonus_unique_wisp_10`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
@@ -6732,27 +6735,26 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         items: {
           starting: [
             `tango`,
+            `tango`,
             `blood_grenade`,
-            `ring_of_regen`,
             `faerie_fire`,
-            `branches`,
+            `circlet`,
             `branches`,
             `branches`,
             `ward_observer`,
             `ward_sentry`,
           ],
           early_game: [
-            `headdress`,
+            `bracer`,
             `magic_wand`,
             `mekansm`,
             `ring_of_basilius`,
             `infused_raindrop`,
           ],
           mid_game: [
-            `pavise`,
-            `solar_crest`,
-            `vladmir`,
             `holy_locket`,
+			`pavise`,
+            `solar_crest`,
             `aghanims_shard`,
             `glimmer_cape`,
           ],
@@ -6769,6 +6771,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `force_staff`,
             `ghost`,
             `pipe`,
+			`vladmir`,
             `lotus_orb`,
             `heavens_halberd`,
             `helm_of_the_overlord`,
@@ -6776,9 +6779,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           core: [
             `mekansm`,
+			`holy_locket`,
             `solar_crest`,
-            `vladmir`,
-            `holy_locket`,
             `aghanims_shard`,
             `glimmer_cape`,
             `heart`,
@@ -7946,6 +7948,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40542,
         power_level: [2.2, 2.3, 2.6, 2.4],
+		facet: 1,
         abilities: [
           "lina_dragon_slave", // 1
           "lina_fiery_soul", // 2
@@ -8002,6 +8005,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `arcane_boots`,
             `blink`,
             `aether_lens`,
+			`yasha_and_kaya`,
             `kaya_and_sange`,
             `ghost`,
             `cyclone`,
@@ -8011,10 +8015,13 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `aghanims_shard`,
             `sphere`,
             `aeon_disk`,
+			`ethereal_blade`,
+			`devastator`,
             `silver_edge`,
             `monkey_king_bar`,
             `bloodthorn`,
             `nullifier`,
+			`assault`,
             `sheepstick`,
             `revenants_brooch`,
             `refresher`,
@@ -8039,7 +8046,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `enchanted_quiver`,
             `paladin_sword`,
             `mind_breaker`,
-            `avianas_feather`,
+            `ancient_guardian`,
             `desolator_2`,
             `pirate_hat`,
           ],
@@ -8051,18 +8058,19 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40737,
         power_level: [1.9, 2, 2.1, 2.2],
+		facet: 2,
         abilities: [
           "lina_light_strike_array", // 1
-          "lina_fiery_soul", // 2
+          `lina_dragon_slave`, // 2
           "lina_dragon_slave", // 3
-          "lina_dragon_slave", // 4
+          `lina_light_strike_array`, // 4
           "lina_dragon_slave", // 5
           "lina_laguna_blade", // 6
           "lina_dragon_slave", // 7
           "lina_light_strike_array", // 8
           "lina_light_strike_array", // 9
-          "lina_light_strike_array", // 10
-          "special_bonus_unique_lina_1", // 11
+          `special_bonus_unique_lina_1`, // 10
+          `lina_fiery_soul`, // 11
           "lina_laguna_blade", // 12
           "lina_fiery_soul", // 13
           "lina_fiery_soul", // 14
@@ -8071,19 +8079,19 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 17
           "lina_laguna_blade", // 18
           "special_bonus_attributes", // 19
-          `special_bonus_unique_lina_2`, // 20
+          `special_bonus_unique_lina_6`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          `special_bonus_unique_lina_crit_debuff`, // 25
+          `special_bonus_unique_lina_7`, // 25
         ],
         items: {
           starting: [
             "tango",
             `tango`,
             `blood_grenade`,
-            `enchanted_mango`,
+            `faerie_fire`,
             `circlet`,
             `branches`,
             `branches`,
@@ -8106,22 +8114,24 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `force_staff`,
           ],
           late_game: [
-            `aghanims_shard`,
             `ultimate_scepter`,
-            `ethereal_blade`,
+            `aghanims_shard`,
             `sheepstick`,
+            `ethereal_blade`,
           ],
           situational: [
             `glimmer_cape`,
             `black_king_bar`,
             `lotus_orb`,
             `ghost`,
+			`yasha_and_kaya`,
             `wind_waker`,
             `gungir`,
             `octarine_core`,
             `aeon_disk`,
             `refresher`,
             `revenants_brooch`,
+			`arcane_blink`,
             `travel_boots`,
           ],
           core: [
@@ -8129,9 +8139,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `aether_lens`,
             "cyclone",
             `blink`,
-            `force_staff`,
-            `aghanims_shard`,
             `ultimate_scepter`,
+            `aghanims_shard`,
             `sheepstick`,
           ],
           neutral: [
@@ -8875,6 +8884,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40535,
         power_level: [1.5, 1.9, 2.6, 2.7],
+		facet: 1,
         abilities: [
           "magnataur_shockwave", // 1
           `magnataur_skewer`, // 2
@@ -8988,6 +8998,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40536,
         power_level: [1.5, 1.9, 2.6, 2.7],
+		facet: 1,
         abilities: [
           "magnataur_shockwave", // 1
           `magnataur_skewer`, // 2
@@ -9102,6 +9113,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40537,
         power_level: [1, 1.8, 2.3, 2.5],
+		facet: 1,
         abilities: [
           "magnataur_shockwave", // 1
           "magnataur_skewer", // 2
@@ -9239,6 +9251,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40538,
         power_level: [2, 2.1, 2.1, 2.1],
+		facet: 1,
         abilities: [
           `marci_grapple`, // 1	equals to rebound
           `marci_companion_run`, // 2	 equals to dispose
@@ -9341,6 +9354,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40539,
         power_level: [1.9, 2.1, 2.5, 2.3],
+		facet: 1,
         abilities: [
           "marci_grapple", // 1	equals to dispose
           `marci_special_delivery`, // 2	equals to rebound
@@ -9509,6 +9523,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40540,
         power_level: [2.2, 2.3, 2.6, 2.7],
+		facet: 2,
         abilities: [
           "mars_gods_rebuke", // 1
           "mars_spear", // 2
@@ -9556,17 +9571,19 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           mid_game: [
             `blink`,
             `black_king_bar`,
-            `shivas_guard`,
+            `desolator`,
             `aghanims_shard`,
+			`cyclone`,
           ],
           late_game: [
-            `sheepstick`,
             `refresher`,
+            `wind_waker`,
             `octarine_core`,
             `overwhelming_blink`,
           ],
           situational: [
-            `vanguard`,
+            `veil_of_discord`,
+			`vanguard`,
             `guardian_greaves`,
             `heavens_halberd`,
             `pipe`,
@@ -9578,11 +9595,15 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `cyclone`,
             `desolator`,
             `ultimate_scepter`,
+			`sheepstick`,
             `heart`,
+			`shivas_guard`,
             `sphere`,
             `assault`,
             `satanic`,
+			`nullifier`,
             `greater_crit`,
+			`revenants_brooch`,
             `travel_boots`,
           ],
           core: [
@@ -9591,10 +9612,9 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `soul_ring`,
             `blink`,
             `black_king_bar`,
-            `shivas_guard`,
-            `aghanims_shard`,
-            `sheepstick`,
+            `desolator`,
             `refresher`,
+            `wind_waker`,
           ],
           neutral: [
             `occult_bracelet`,
@@ -9602,7 +9622,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `bullwhip`,
             `dragon_scale`,
             `ceremonial_robe`,
-            "cloak_of_flames",
+            `nemesis_curse`,
             `havoc_hammer`,
             `rattlecage`,
             `desolator_2`,
@@ -13177,6 +13197,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40549,
         power_level: [2.1, 2.3, 2.6, 2.7],
+		facet: 1,
         abilities: [
           "puck_illusory_orb", // 1
           "puck_phase_shift", // 2
@@ -13208,13 +13229,13 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           starting: [
             "tango",
             `faerie_fire`,
-            `branches`,
+            `circlet`,
             "branches",
             "branches",
             `branches`,
             `ward_observer`,
           ],
-          early_game: ["bottle", `power_treads`, `magic_wand`, `wind_lace`],
+          early_game: [`bottle`, `null_talisman`, `power_treads`, `magic_wand`, `wind_lace`],
 
           mid_game: [
             `witch_blade`,
@@ -13228,10 +13249,10 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `octarine_core`,
             `aghanims_shard`,
             `greater_crit`,
-            `revenants_brooch`,
+            `mjollnir`,
           ],
           situational: [
-            `null_talisman`,
+            `veil_of_discord`,
             `cyclone`,
             "sphere",
             `maelstrom`,
@@ -13242,9 +13263,9 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             "aeon_disk",
             `refresher`,
             `shivas_guard`,
-            `mjollnir`,
             `ethereal_blade`,
             `sheepstick`,
+			`revenants_brooch`,
             `overwhelming_blink`,
             `travel_boots`,
           ],
@@ -13257,7 +13278,6 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `devastator`,
             `ultimate_scepter`,
             `octarine_core`,
-            `greater_crit`,
           ],
           neutral: [
             "mysterious_hat",
@@ -13298,8 +13318,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "eternal_shroud",
           "black_king_bar",
           "orchid",
-          "sange_and_yasha",
-          "kaya_and_sange",
+          `sange_and_yasha`,
           "manta",
         ],
       },
@@ -13540,6 +13559,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40550,
         power_level: [2.1, 2.3, 2.3, 1.9],
+		facet: 1,
         abilities: [
           "pugna_nether_blast", // 1
           "pugna_decrepify", // 2
@@ -13644,6 +13664,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40551,
         power_level: [1.9, 2.1, 1.9, 1.7],
+		facet: 1,
         abilities: [
           "pugna_nether_blast", // 1
           `pugna_nether_ward`, // 2
@@ -15789,7 +15810,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
   // eidendota plays hero
   slark: {
     gameplay_version: "7.36a",
-    creator: ContentCreator.yongy146,
+    creator: ContentCreator.YoonA,
     damage_type: DamageType.physical,
     builds: [
       {
@@ -15798,6 +15819,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40638,
         power_level: [1.7, 2, 2.6, 2.6],
+		facet: 1,
         abilities: [
           "slark_essence_shift", // 1
           "slark_pounce", // 2
@@ -15808,8 +15830,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "slark_dark_pact", // 7
           "slark_pounce", // 8
           "slark_pounce", // 9
-          "special_bonus_unique_slark_6", // 10
-          "slark_pounce", // 11
+          `slark_pounce`, // 10
+          `special_bonus_unique_slark_6`, // 11
           "slark_shadow_dance", // 12
           "slark_essence_shift", // 13
           "slark_essence_shift", // 14
@@ -15818,7 +15840,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 17
           "slark_shadow_dance", // 18
           "special_bonus_attributes", // 19
-          "special_bonus_unique_slark_7", // 20
+          `special_bonus_unique_slark_5`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
@@ -15829,64 +15851,70 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           starting: [
             "tango",
             "quelling_blade",
-            "branches",
-            "circlet",
-            "slippers",
+            `slippers`,
+            `circlet`,
+            `branches`,
+			`branches`,
           ],
           early_game: [
             "wraith_band",
-            "magic_wand",
-            "power_treads",
-            "diffusal_blade",
+            `power_treads`,
+            `magic_wand`,
+            `infused_raindrop`,
           ],
           mid_game: [
-            "echo_sabre",
+            `diffusal_blade`,
+			`orchid`,
             "ultimate_scepter",
             "aghanims_shard",
             "black_king_bar",
           ],
           late_game: [
-            "disperser",
-            "moon_shard",
-            "harpoon",
+            `skadi`,
+			`disperser`,
             "abyssal_blade",
-            "skadi",
+            `bloodthorn`,
           ],
           situational: [
             "orb_of_venom",
             "orb_of_corrosion",
-            "hand_of_midas",
+            `hand_of_midas`,
+			`echo_sabre`,
+			`harpoon`,
+			`basher`,
+			`blink`,
             "sange_and_yasha",
             "sphere",
             "monkey_king_bar",
             "nullifier",
             "mage_slayer",
             "silver_edge",
-            "butterfly",
+            `butterfly`,
+			`moon_shard`,
+			`swift_blink`,
+			`travel_boots`,
           ],
           core: [
             "power_treads",
             "diffusal_blade",
-            "echo_sabre",
+            `orchid`,
             "ultimate_scepter",
             "aghanims_shard",
-            "black_king_bar",
+            `black_king_bar`,
+			`skadi`,
+			`abyssal_blade`,
           ],
           neutral: [
             "lance_of_pursuit",
             "occult_bracelet",
-            //"possessed_mask", Removed in 7.33
-            //"dagger_of_ristul", Removed in 7.33
-            //"misericorde",
-            //"ring_of_aquila",
+            `vambrace`,
             "orb_of_destruction",
             "elven_tunic",
-            //"titan_sliver",
+            `nemesis_curse`,
             "mind_breaker",
-            //"penta_edged_sword",
-            "pirate_hat",
-            "apex",
-            "mirror_shield",
+            `ancient_guardian`,
+            `apex`,
+			`pirate_hat`,
           ],
         },
       },
@@ -15899,12 +15927,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         core: [],
       },
       mid_game: {
-        all: [],
+        all: [`wind_waker`],
         support: ["force_staff", "glimmer_cape", "ghost", "ward_sentry"],
         core: ["hurricane_pike", "heavens_halberd", "basher"],
       },
       late_game: {
-        all: ["sheepstick", "ethereal_blade"],
+        all: [`sheepstick`, `ethereal_blade`, `wind_waker`],
         support: ["SentryGem"],
         core: ["abyssal_blade", "butterfly", "bloodthorn"],
       },
@@ -15922,6 +15950,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40601,
         power_level: [2.1, 2.1, 2, 2.1],
+		facet: 2,
         abilities: [
           "snapfire_scatterblast", // 1
           "snapfire_firesnap_cookie", // 2
@@ -15954,8 +15983,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             "tango",
             "tango",
             "blood_grenade",
-            "enchanted_mango",
-            "circlet",
+            `circlet`,
+            `branches`,
             "branches",
             "branches",
             "ward_observer",
@@ -15970,16 +15999,17 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           mid_game: [
             `arcane_boots`,
-            `pavise`,
-            `solar_crest`,
+            `mekansm`,
             `force_staff`,
             `aghanims_shard`,
             `guardian_greaves`,
           ],
-          late_game: ["ultimate_scepter", `blink`, `octarine_core`, `gungir`],
+          late_game: [`ultimate_scepter`, `blink`, `octarine_core`, `wind_waker`],
           situational: [
             `bracer`,
             `spirit_vessel`,
+			`pavise`,
+            `solar_crest`,
             `glimmer_cape`,
             `rod_of_atos`,
             `ghost`,
@@ -15989,22 +16019,22 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `pipe`,
             `cyclone`,
             `aeon_disk`,
+			`gungir`,
             `sheepstick`,
             `travel_boots`,
           ],
           core: [
             "arcane_boots",
-            `solar_crest`,
+            `mekansm`,
             `force_staff`,
             `aghanims_shard`,
             `guardian_greaves`,
             `ultimate_scepter`,
             `blink`,
-            `octarine_core`,
           ],
           neutral: [
             `arcane_ring`,
-            `unstable_wand`,
+            `trusty_shovel`,
             "philosophers_stone",
             `pupils_gift`,
             `ceremonial_robe`,
@@ -17667,23 +17697,24 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40553,
         power_level: [2.4, 2.6, 2.4, 2.3],
+		facet: 2,
         abilities: [
           "shredder_whirling_death", // 1
           "shredder_reactive_armor", // 2
-          "shredder_reactive_armor", // 3
-          "shredder_timber_chain", // 4
+          `shredder_timber_chain`, // 3
+          `shredder_whirling_death`, // 4
           `shredder_timber_chain`, // 5
           "shredder_chakram", // 6
           "shredder_timber_chain", // 7
           "shredder_timber_chain", // 8
           `shredder_whirling_death`, // 9
-          `shredder_whirling_death`, // 10
+          `special_bonus_mp_regen_150`, // 10
           `shredder_whirling_death`, // 11
           "shredder_chakram", // 12
           `shredder_reactive_armor`, // 13
           `shredder_reactive_armor`, // 14
-          `special_bonus_mp_regen_150`, // 15
-          `special_bonus_unique_timbersaw_5`, // 16
+          `special_bonus_unique_timbersaw_5`, // 15
+          `shredder_reactive_armor`, // 16
           "special_bonus_attributes", // 17
           "shredder_chakram", // 18
           "special_bonus_attributes", // 19
@@ -17692,7 +17723,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          "special_bonus_unique_timbersaw", // 25
+          `special_bonus_unique_timbersaw_3`, // 25
         ],
         items: {
           starting: [
@@ -17705,65 +17736,66 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ward_observer`,
           ],
           early_game: [
-            `arcane_boots`,
+            `bracer`,
+			`arcane_boots`,
             `soul_ring`,
-            `veil_of_discord`,
             "magic_wand",
             `wind_lace`,
           ],
           mid_game: [
-            `eternal_shroud`,
+            `kaya`,
+			`eternal_shroud`,
             `kaya_and_sange`,
-            `shivas_guard`,
             `ultimate_scepter`,
-            `aghanims_shard`,
+            `shivas_guard`,
           ],
           late_game: [
             `blink`,
+			`aghanims_shard`,
+            `wind_waker`,
             `sheepstick`,
-            `octarine_core`,
-            `overwhelming_blink`,
           ],
           situational: [
             "orb_of_corrosion",
-            `bracer`,
+            `veil_of_discord`,
             `vanguard`,
+			`meteor_hammer`,
             `cyclone`,
             `bloodstone`,
             `crimson_guard`,
             `pipe`,
-            `eternal_shroud`,
             `guardian_greaves`,
             `lotus_orb`,
             `heavens_halberd`,
             `black_king_bar`,
             `sphere`,
             `aeon_disk`,
+			`octarine_core`,
             `heart`,
+			`overwhelming_blink`,
             `travel_boots`,
           ],
           core: [
-            `arcane_boots`,
+            `bracer`,
+			`arcane_boots`,
             `soul_ring`,
-            `veil_of_discord`,
             `eternal_shroud`,
             `kaya_and_sange`,
-            `shivas_guard`,
             `ultimate_scepter`,
-            `aghanims_shard`,
-            `sheepstick`,
+            `shivas_guard`,
+            `wind_waker`,
           ],
           neutral: [
             "arcane_ring",
             `occult_bracelet`,
             `vambrace`,
-            `pupils_gift`,
+            `bullwhip`,
             `craggy_coat`,
             "cloak_of_flames",
             `rattlecage`,
-            `timeless_relic`,
-            `apex`,
+            `havoc_hammer`,
             `giants_ring`,
+            `mirror_shield`,
           ],
         },
       },
@@ -17956,6 +17988,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40554,
         power_level: [1, 1.9, 2.2, 2.2],
+		facet: 1,
         abilities: [
           `tiny_tree_grab`, // 1
           "tiny_avalanche", // 2
@@ -18055,6 +18088,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40555,
         power_level: [1.7, 2.2, 2.6, 2.5],
+		facet: 2,
         abilities: [
           "tiny_tree_grab", // 1
           "tiny_avalanche", // 2
@@ -18163,6 +18197,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40556,
         power_level: [1.7, 1.9, 2.7, 2.6],
+		facet: 2,
         abilities: [
           "tiny_tree_grab", // 1
           "tiny_avalanche", // 2
@@ -19743,6 +19778,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40558,
         power_level: [2.1, 2.5, 2.3, 2.3],
+		facet: 1,
         abilities: [
           "viper_poison_attack", // 1
           "viper_corrosive_skin", // 2
@@ -19754,7 +19790,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           `viper_corrosive_skin`, // 8
           "viper_corrosive_skin", // 9
           `viper_corrosive_skin`, // 10
-          `special_bonus_unique_viper_1`, // 11
+          `special_bonus_unique_viper_4`, // 11
           "viper_viper_strike", // 12
           `viper_nethertoxin`, // 13
           "viper_nethertoxin", // 14
@@ -19789,12 +19825,13 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           mid_game: [
             `mage_slayer`,
+			`dragon_lance`,
             `hurricane_pike`,
-            `ultimate_scepter`,
-            `aghanims_shard`,
             `manta`,
+            `aghanims_shard`,
+            `black_king_bar`,
           ],
-          late_game: [`skadi`, `black_king_bar`, `sheepstick`, `butterfly`],
+          late_game: [`skadi`, `ultimate_scepter`, `assault`, `butterfly`],
           situational: [
             `ring_of_basilius`,
             `veil_of_discord`,
@@ -19814,7 +19851,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `heavens_halberd`,
             `shivas_guard`,
             `bloodthorn`,
-            `assault`,
+            `sheepstick`,
             `travel_boots`,
           ],
           core: [
@@ -19822,11 +19859,10 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `power_treads`,
             `mage_slayer`,
             `hurricane_pike`,
-            `ultimate_scepter`,
-            `aghanims_shard`,
             `manta`,
-            `skadi`,
+            `aghanims_shard`,
             `black_king_bar`,
+            `skadi`,
           ],
           neutral: [
             `mysterious_hat`,
@@ -19851,6 +19887,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40559,
         power_level: [2.3, 2.5, 2.3, 2.3],
+		facet: 1,
         abilities: [
           "viper_poison_attack", // 1
           "viper_corrosive_skin", // 2
@@ -19882,10 +19919,10 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           starting: [
             "tango",
             "faerie_fire",
-            `branches`,
-            `branches`,
-            `branches`,
             `circlet`,
+            `branches`,
+            `branches`,
+            `branches`,
             `ward_observer`,
           ],
           early_game: [
@@ -19896,18 +19933,19 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `wind_lace`,
           ],
           mid_game: [
-            `mage_slayer`,
+            `dragon_lance`,
             `hurricane_pike`,
             `manta`,
-            `ultimate_scepter`,
             `aghanims_shard`,
+            `black_king_bar`,
           ],
-          late_game: [`black_king_bar`, `skadi`, `bloodthorn`, `butterfly`],
+          late_game: [`skadi`, `bloodthorn`, `ultimate_scepter`, `butterfly`],
           situational: [
             `ring_of_basilius`,
             `falcon_blade`,
             `hand_of_midas`,
             `veil_of_discord`,
+			`orchid`,
             `blink`,
             `bloodstone`,
             `kaya_and_sange`,
@@ -19923,18 +19961,17 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `devastator`,
             `shivas_guard`,
             `assault`,
-            `travel_boots_2`,
+            `travel_boots`,
           ],
           core: [
             `bottle`,
             `power_treads`,
-            `mage_slayer`,
             `hurricane_pike`,
             `manta`,
-            `ultimate_scepter`,
             `aghanims_shard`,
             `black_king_bar`,
             `skadi`,
+            `bloodthorn`,
           ],
           neutral: [
             `mysterious_hat`,

--- a/content/messages.ts
+++ b/content/messages.ts
@@ -710,7 +710,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audience: [Audience.ALL],
     image: { type: "ability", name: "abaddon_aphotic_shield" },
   },
-  {
+  /* {
     category: "EnemyHero",
     npcHeroName: "abaddon",
     audioFile: "enemyHero/Abaddon_2_CurseOfAvernus",
@@ -719,7 +719,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
       "It takes four attacks from Abaddon's Curse of Avernus to silence and slow you significantly.",
     audience: [Audience.ALL],
     image: { type: "ability", name: "abaddon_frostmourne" },
-  },
+  }, */
   {
     category: "EnemyHero",
     npcHeroName: "abaddon",
@@ -6171,10 +6171,10 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
   {
     category: "OwnHero",
     npcHeroName: "wisp",
-    audioFile: "ownHero/Io_4_BoostCarry",
+    audioFile: `ownHero/Io_4_BoostFightingCore`,
     messageTime: 10 * 60 + 15,
     textMessage:
-      "Past laning stage, you typically want to play with your farming core to boost his farm and stack camps.",
+      `Past laning stage, you typically want to play with a core on your team who plays aggressively and utilizes their HP and mana pool while you buff them with Tether and Overcharge.`,
     audience: [Audience.ALL],
   },
   {
@@ -6215,7 +6215,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Io_8_AghanimsShard",
     messageTime: 14 * 60 + 50,
     textMessage:
-      "Pick up Aghanim's Shard at minute 15. It provides a source of disable that opponents are typically unaware of.",
+      `Pick up Aghanims Shard later in the game to gain spell lifesteal and slow resistance through Overcharge for yourself and your Tethered ally.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
   },
@@ -6242,6 +6242,15 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     ],
     textMessage:
       "Grab the healing lotus to have a burst of HP and mana regen for yourself and the tethered ally.",
+    audience: [Audience.ALL],
+  },
+  {
+    category: `OwnHero`,
+    npcHeroName: `wisp`,
+    audioFile: `ownHero/Io_11_BoostFarmingCore`,
+    messageTime: 11 * 60 + 15,
+    textMessage:
+      `Past laning stage, if you do not have fighting core hero on your team, look to play with your farming core to boost his farm and stack camps.`,
     audience: [Audience.ALL],
   },
 
@@ -7661,7 +7670,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Lina_6_UpkeepFierySoul",
     messageTime: [7 * 60, 17 * 60, 27 * 60],
     textMessage:
-      "Use Dragon Slave on creep waves to maintain Fiery Soul Stacks as you can hit more creeps consistently with it.",
+      `Use Dragon Slave on creep waves to maintain Fiery Soul Stacks and keep your maximum damage potential in fights and for farming.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "lina_dragon_slave" },
   },
@@ -7672,7 +7681,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 10 * 60 + 15,
     repeatTime: 10 * 60,
     textMessage:
-      "Lina is great at split-pushing and pick-offs due to high movement speed, great waveclear and damage burst.",
+      `Lina is great at split pushing with her quick wave clear abilities, as well as pick offs due to her high movement speed and massive burst damage.`,
     audience: [Audience.ALL],
   },
   {
@@ -8644,7 +8653,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: "marci",
     audioFile: "enemyHero/Marci_1_SpiritVessel",
     messageTime: -60,
-    textMessage: "Someone should buy spirit Vessel against Marci's Sidekick.",
+    textMessage: `Someone should buy spirit Vessel against Marcis Sidekick and Bodyguard.`,
     audience: [Audience.ALL],
   },
   {
@@ -8680,7 +8689,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/Marci_5_AntiHealingItems",
     messageTime: [12 * 60 + 10, 22 * 60 + 10, 32 * 60 + 10],
     textMessage:
-      "Items that reduce healing and regeneration are good against Marci's Sidekick.",
+      `Items that reduce healing and regeneration are good against Marcis Sidekick and Bodyguard.`,
     audience: [Audience.ALL],
   },
   {
@@ -8689,7 +8698,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/Marci_6_DispelItems",
     messageTime: [12 * 60 + 20, 22 * 60 + 20, 32 * 60 + 20],
     textMessage:
-      "Items that can dispel Sidekick or Rebound buff from Marci or her ally are great purchase.",
+      `Items that can dispel the Rebound buff from Marci or her ally are great purchase.`,
     audience: [Audience.ALL],
   },
   {
@@ -12001,7 +12010,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: "puck",
     audioFile: "ownHero/Puck_5_OrbScouting",
     messageTime: [2 * 60, 10 * 60, 18 * 60],
-    textMessage: `Illusory Orb provides vision on its path so you can check for pillar wards and scout Rosh pit.`,
+    textMessage: `Illusory Orb provides vision on its path so you can check for pillar wards and scout Roshan pit.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "puck_illusory_orb" },
   },
@@ -13950,7 +13959,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Slark_1_ScoutWards",
     messageTime: -90,
     textMessage:
-      "As you load into the game, start running to scout opponents placing wards as you have night vision.",
+      `As you load into the game, start running to scout opponents placing wards as you have high night vision.`,
     audience: [Audience.ALL],
   },
   {
@@ -13959,7 +13968,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Slark_2_DamageDifference",
     messageTime: 15,
     textMessage:
-      "Hit an opponent whenever you can to create a damage difference of 4. It'll help you with lasthiting.",
+      `Hit an opponent whenever you can to create a damage difference of 4. It'll help you with last hiting.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "slark_essence_shift" },
   },
@@ -13969,7 +13978,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Slark_3_GoPounce",
     messageTime: 75,
     textMessage:
-      "If you are able to build up a few Essence Shift stacks, you can perhaps commit for a kill attempt with Pounce.",
+      `If you are able to build up a few Essence Shift stacks, look to commit for a kill attempt with Pounce.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "slark_pounce" },
   },
@@ -14030,9 +14039,18 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Slark_9_AghanimsShard",
     messageTime: 15 * 60,
     textMessage:
-      "Slarks aghanims shard is very good for man fighting and saving allies, consider purchasing after your 3 main items.",
+      `Slarks Aghanims Shard is very good for man fighting and saving allies, consider purchasing after your 3 main items.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
+  },
+  {
+    category: `OwnHero`,
+    npcHeroName: `slark`,
+    audioFile: `ownHero/Slark_10_AghanimsShard`,
+    messageTime: [45, 2 * 60 + 45, 4 * 60 + 45, 6 * 60 + 45],
+    textMessage:
+      `When low on HP, look to get out of enemy vision to gain some HP regen from your Barracuda innate.`,
+    audience: [Audience.ALL],
   },
 
   {
@@ -14041,9 +14059,9 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/Slark_1_OfflaneMelee",
     messageTime: -90,
     textMessage:
-      "Slark tends to do well against offlane melee due to Essence Shift stacks. Check if you can send at least one ranged hero against him",
+      `Slark tends to do well against melee offlane heroes due to Essence Shift stacks. Check if you can send at least one ranged hero against him`,
     chatMessage:
-      "Slark tends to do well against offlane melee due to Essence Shift stacks. Send one ranged hero against him",
+      `Slark tends to do well against melee offlane heroes due to Essence Shift stacks. Send one ranged hero against him`,
     audience: [Audience.ALL],
   },
   {
@@ -14064,14 +14082,14 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
       "Keep an eye on Slark's Dark Pact usage so that your spells and items don't get dispelled",
     audience: [Audience.ALL],
   },
-  {
+  /* {
     category: "EnemyHero",
     npcHeroName: "slark",
     audioFile: "enemyHero/Slark_4_ForceStaff",
     messageTime: 8 * 60 + 30,
     textMessage: "Force Staff allows you to break away from Slark's Pounce",
     audience: [Audience.ALL],
-  },
+  }, */
 
   {
     category: "EnemyHero",
@@ -14195,6 +14213,16 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audience: [Audience.ALL],
     image: { type: "ability", name: "snapfire_lil_shredder" },
   },
+  {
+    category: `OwnHero`,
+    npcHeroName: `snapfire`,
+    audioFile: `ownHero/Snapfire_10_FullBoreFacet`,
+    messageTime: [-45, 45, 3 * 60 + 45, 8 * 60 + 45, 13 * 60 + 45],
+    textMessage:
+      `With the Full Bore facet, look to keep more than 650 units distance from enemy heroes when hitting them with Scatterblast to do maximum damage.`,
+    audience: [Audience.ALL],
+    image: { type: `ability`, name: `snapfire_scatterblast` },
+  },
 
   {
     category: "EnemyHero",
@@ -14202,9 +14230,9 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/Snapfire_1_Scatterblast",
     messageTime: -10,
     textMessage:
-      "Avoid staying too close to Snapfire on the lane as her main harassing spell is Scatterblast which does 50% more damage if you are within 450 range",
+      `If Snapfire has the Ricochet II facet, avoid staying too close to Snapfire on the lane as her main harassing spell is Scatterblast which does 50% more damage if you are within 450 range`,
     chatMessage:
-      "Avoid staying close to Snapfire as her Scatterblast which does 50% more damage if you are within 450 range",
+      `If Snapfire has the Ricochet II facet, avoid staying close to Snapfire as her Scatterblast which does 50% more damage if you are within 450 range`,
     audience: [Audience.IN_LANE],
   },
   {
@@ -15860,7 +15888,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Timbersaw_11_NoToLategame",
     messageTime: [22 * 60, 27 * 60],
     textMessage:
-      "You don't necessarily want to go to late game, so try to close the game down before you fall off.",
+      `You do not necessarily want to go to late game, so try to close out the game before you fall off.`,
     audience: [Audience.ALL],
   },
 
@@ -17582,6 +17610,15 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 12 * 60 + 10,
     textMessage:
       "Linken's Sphere and a well timed Lotus Orb are great against Viper Strike.",
+    audience: [Audience.ALL],
+  },
+  {
+    category: `EnemyHero`,
+    npcHeroName: `viper`,
+    audioFile: `enemyHero/Viper_6_PoisonBurstFacet`,
+    messageTime: [1 * 60 + 15, 8 * 60 + 15, 19 * 60 + 15],
+    textMessage:
+      `When Viper has the Poison Burst facet, try not to stand next to the target he is attacking with Poison Attack to avoid its AoE burst damage.`,
     audience: [Audience.ALL],
   },
 


### PR DESCRIPTION
Updated the guides for the following heroes:
IO (Support)
Snapfire (Support)
Slark (Carry)
Timbersaw (Offlane)
Lina (Support & Mid)
Viper (Offlane & Mid)
Mars (Offlane)
Puck (Mid)

Also added facets for all the previously updated heroes.