### PR TITLE
Updated Hero Guides

### DIFF
--- a/content/heroBuilds.ts
+++ b/content/heroBuilds.ts
@@ -3000,39 +3000,40 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          `special_bonus_unique_clinkz_4`, // 25
+          `special_bonus_unique_clinkz_3`, // 25
         ],
         items: {
           starting: [
             "tango",
-            "branches",
-            "branches",
-            "slippers",
-            "circlet",
-            "quelling_blade",
+            `quelling_blade`,
+            `slippers`,
+            `circlet`,
+            `branches`,
+            `branches`,
           ],
           early_game: [
-            `magic_wand`,
             `wraith_band`,
-            `falcon_blade`,
-            "power_treads",
+            `ring_of_basilius`,
+            `arcane_boots`,
+            `magic_wand`,
             `infused_raindrop`,
           ],
           mid_game: [
             `desolator`,
             `dragon_lance`,
-            `orchid`,
-            `bloodthorn`,
+            `greater_crit`,
             `aghanims_shard`,
           ],
           late_game: [
             `hurricane_pike`,
-            `greater_crit`,
             `black_king_bar`,
+            `skadi`,
             `sheepstick`,
           ],
           situational: [
-            `phylactery`,
+            `power_treads`,
+			`falcon_blade`,
+			`phylactery`,
             `blink`,
             `mage_slayer`,
             `diffusal_blade`,
@@ -3040,7 +3041,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `maelstrom`,
             `gungir`,
             `angels_demise`,
-            `skadi`,
+			`orchid`,
+            `bloodthorn`,
             "monkey_king_bar",
             "sphere",
             "ultimate_scepter",
@@ -3050,14 +3052,13 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `travel_boots`,
           ],
           core: [
-            `falcon_blade`,
-            `power_treads`,
+            `arcane_boots`,
             `desolator`,
-            `bloodthorn`,
+			`dragon_lance`,
+            `greater_crit`,
             `aghanims_shard`,
             `hurricane_pike`,
-            `greater_crit`,
-            `sheepstick`,
+            `black_king_bar`,
           ],
           neutral: [
             "lance_of_pursuit",
@@ -3908,6 +3909,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40473,
         power_level: [1.8, 1.7, 1.9, 2],
+		facet: [1, 2],
         abilities: [
           "dazzle_poison_touch", // 1
           "dazzle_shadow_wave", // 2
@@ -3959,18 +3961,20 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `aghanims_shard`,
             `force_staff`,
           ],
-          late_game: [`aether_lens`, `blink`, `aeon_disk`, `ultimate_scepter`],
+          late_game: [`aether_lens`, `blink`, `aeon_disk`, `wind_waker`],
           situational: [
             `spirit_vessel`,
             `hand_of_midas`,
             `cyclone`,
             `ghost`,
+			`mekansm`,
             `boots_of_bearing`,
             `holy_locket`,
             `guardian_greaves`,
             `pipe`,
             `lotus_orb`,
             `sheepstick`,
+			`ultimate_scepter`,
             `shivas_guard`,
             `travel_boots`,
           ],
@@ -4684,6 +4688,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40561,
         power_level: [1.2, 1.8, 2.1, 2.1],
+		facet: 1,
         abilities: [
           `earth_spirit_boulder_smash`, // 1
           `earth_spirit_rolling_boulder`, // 2
@@ -4709,7 +4714,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          `special_bonus_unique_earth_spirit_3`, // 25
+          `special_bonus_unique_earth_spirit_2`, // 25
         ],
         items: {
           starting: [
@@ -4718,33 +4723,32 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `blood_grenade`,
             `branches`,
             `branches`,
-            "orb_of_venom",
             `ward_observer`,
+            `ward_sentry`,
           ],
           early_game: [
-            `ward_sentry`,
             `urn_of_shadows`,
             "tranquil_boots",
             "magic_wand",
             `infused_raindrop`,
           ],
           mid_game: [
-            `veil_of_discord`,
             `spirit_vessel`,
+            `veil_of_discord`,
             `aghanims_shard`,
             `black_king_bar`,
+			`cyclone`,
           ],
           late_game: [
             `shivas_guard`,
             `blink`,
             `ultimate_scepter`,
-            `octarine_core`,
+            `wind_waker`,
           ],
           situational: [
             `arcane_boots`,
             `pavise`,
             `ghost`,
-            `cyclone`,
             `force_staff`,
             `glimmer_cape`,
             `kaya_and_sange`,
@@ -4754,14 +4758,14 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `solar_crest`,
             `ethereal_blade`,
             `aeon_disk`,
+			`octarine_core`,
             `overwhelming_blink`,
-            `wind_waker`,
             `travel_boots`,
           ],
           core: [
             `urn_of_shadows`,
-            `veil_of_discord`,
             `spirit_vessel`,
+			`veil_of_discord`,
             `aghanims_shard`,
             `black_king_bar`,
             `shivas_guard`,
@@ -4773,12 +4777,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `arcane_ring`,
             `dragon_scale`,
             `bullwhip`,
-            `craggy_coat`,
             `ceremonial_robe`,
+            `craggy_coat`,
             "timeless_relic",
             `havoc_hammer`,
             `giants_ring`,
-            `panic_button`,
+            `force_field`,
           ],
         },
       },
@@ -5239,21 +5243,22 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40565,
         power_level: [2.3, 2, 2.1, 1.8],
+		facet: 2,
         abilities: [
-          `enchantress_impetus`, // 1
-          `enchantress_enchant`, // 2
+          `enchantress_enchant`, // 1
+          `enchantress_impetus`, // 2
           "enchantress_enchant", // 3
           `enchantress_natures_attendants`, // 4
           `enchantress_enchant`, // 5
           `enchantress_impetus`, // 6
-          `enchantress_impetus`, // 7
+          `enchantress_enchant`, // 7
           `enchantress_impetus`, // 8
-          `enchantress_untouchable`, // 9
-          `enchantress_natures_attendants`, // 10
+          `enchantress_impetus`, // 9
+          `enchantress_untouchable`, // 10
           `enchantress_natures_attendants`, // 11
           "enchantress_untouchable", // 12
           `enchantress_natures_attendants`, // 13
-          `enchantress_enchant`, // 14
+          `enchantress_natures_attendants`, // 14
           `special_bonus_unique_enchantress_6`, // 15
           `special_bonus_attack_damage_45`, // 16
           "special_bonus_attributes", // 17
@@ -5279,16 +5284,18 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ward_sentry`,
           ],
           early_game: [
-            `power_treads`,
+            `null_talisman`,
+			`power_treads`,
             `magic_wand`,
             `infused_raindrop`,
             `fluffy_hat`,
           ],
           mid_game: [
             `force_staff`,
+			`dragon_lance`,
             `hurricane_pike`,
             `aghanims_shard`,
-            `mage_slayer`,
+            `eternal_shroud`,
           ],
           late_game: [
             `ultimate_scepter`,
@@ -5301,6 +5308,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `tranquil_boots`,
             `spirit_vessel`,
             `witch_blade`,
+			`mage_slayer`,
             `pavise`,
             `solar_crest`,
             `holy_locket`,
@@ -5320,7 +5328,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `power_treads`,
             `hurricane_pike`,
             `aghanims_shard`,
-            `mage_slayer`,
+            `eternal_shroud`,
             `ultimate_scepter`,
             `black_king_bar`,
             `sheepstick`,
@@ -5330,12 +5338,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `seeds_of_serenity`,
             `grove_bow`,
             `pupils_gift`,
-            `dandelion_amulet`,
-            "enchanted_quiver",
+            `enchanted_quiver`,
+            `vindicators_axe`,
             "spy_gadget",
             `trickster_cloak`,
-            `demonicon`,
             `pirate_hat`,
+            `demonicon`,
           ],
         },
       },
@@ -7088,15 +7096,16 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40563,
         power_level: [1.8, 2, 1.9, 1.7],
+		facet: 1,
         abilities: [
-          `keeper_of_the_light_blinding_light`, // 1  "keeper_of_the_light_radiant_bind" equals to `solar bind`
+          `keeper_of_the_light_illuminate`, // 1  "keeper_of_the_light_radiant_bind" equals to `solar bind`
           `keeper_of_the_light_chakra_magic`, // 2
-          `keeper_of_the_light_illuminate`, // 3
+          `keeper_of_the_light_blinding_light`, // 3
           `keeper_of_the_light_illuminate`, // 4
-          `keeper_of_the_light_chakra_magic`, // 5
+          `keeper_of_the_light_illuminate`, // 5
           "keeper_of_the_light_spirit_form", // 6
           `keeper_of_the_light_illuminate`, // 7
-          `keeper_of_the_light_illuminate`, // 8
+          `keeper_of_the_light_chakra_magic`, // 8
           `keeper_of_the_light_chakra_magic`, // 9
           `keeper_of_the_light_chakra_magic`, // 10
           `special_bonus_unique_keeper_of_the_light_illuminate_cooldown`, // 11
@@ -7113,7 +7122,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          `special_bonus_unique_keeper_of_the_light_14`, // 25
+          `special_bonus_unique_keeper_of_the_light`, // 25
         ],
         items: {
           starting: [
@@ -7135,26 +7144,28 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           mid_game: [
             `spirit_vessel`,
-            `pavise`,
-            `solar_crest`,
-            `force_staff`,
             `glimmer_cape`,
-            `aghanims_shard`,
+            `force_staff`,
+            `cyclone`,
+            `ultimate_scepter`,
           ],
           late_game: [
-            `ultimate_scepter`,
+            `aghanims_shard`,
             `sheepstick`,
-            `ethereal_blade`,
+            `wind_waker`,
             `dagon_5`,
           ],
           situational: [
             `veil_of_discord`,
+			`pavise`,
+            `solar_crest`,
+			`mekansm`,
             `aether_lens`,
             `ghost`,
             `octarine_core`,
             "lotus_orb",
-            "blink",
-            `cyclone`,
+            `blink`,
+			`ethereal_blade`,
             `aeon_disk`,
             `refresher`,
             "travel_boots",
@@ -7162,12 +7173,11 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           core: [
             `tranquil_boots`,
             `spirit_vessel`,
-            `solar_crest`,
             `force_staff`,
-            `aghanims_shard`,
             `ultimate_scepter`,
+            `aghanims_shard`,
             `sheepstick`,
-            `ethereal_blade`,
+            `wind_waker`,
           ],
           neutral: [
             `mysterious_hat`,
@@ -11488,11 +11498,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40564,
         power_level: [0.7, 1.9, 2.2, 2.2],
+		facet: 1,
         abilities: [
           "nyx_assassin_impale", // 1
-          "nyx_assassin_spiked_carapace", // 2
+          `nyx_assassin_jolt`, // 2
           "nyx_assassin_impale", // 3
-          `nyx_assassin_jolt`, // 4
+          `nyx_assassin_spiked_carapace`, // 4
           "nyx_assassin_impale", // 5
           "nyx_assassin_vendetta", // 6
           "nyx_assassin_impale", // 7
@@ -11513,24 +11524,22 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
           "special_bonus_attributes", // 24
-          `special_bonus_unique_nyx_vendetta_cd_manacost`, // 25
+          `special_bonus_unique_nyx`, // 25
         ],
         items: {
           starting: [
             `tango`,
             `tango`,
             `blood_grenade`,
-            `enchanted_mango`,
+            `faerie_fire`,
             `wind_lace`,
-            `branches`,
             `ward_observer`,
+            `ward_sentry`,
           ],
           early_game: [
-            `ward_sentry`,
             `boots`,
             `magic_wand`,
             `ring_of_basilius`,
-            `wind_lace`,
             `infused_raindrop`,
           ],
           mid_game: [
@@ -11540,7 +11549,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ultimate_scepter`,
             `aether_lens`,
           ],
-          late_game: [`blink`, `octarine_core`, `ethereal_blade`, `wind_waker`],
+          late_game: [`blink`, `octarine_core`, `wind_waker`, `ethereal_blade`],
           situational: [
             `spirit_vessel`,
             `meteor_hammer`,
@@ -11562,7 +11571,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ultimate_scepter`,
             `blink`,
             `octarine_core`,
-            `ethereal_blade`,
+            `wind_waker`,
           ],
           neutral: [
             `arcane_ring`,
@@ -11574,7 +11583,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `timeless_relic`,
             `ascetic_cap`,
             `seer_stone`,
-            `panic_button`,
+            `force_boots`,
           ],
         },
       },
@@ -13050,6 +13059,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40684,
         power_level: [1.9, 2.3, 2.4, 2.4],
+		facet: 1,
         abilities: [
           `primal_beast_uproar`, // 1
           `primal_beast_trample`, // 2
@@ -13088,35 +13098,37 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ward_observer`,
           ],
           early_game: [
-            `phase_boots`,
+            `bracer`,
+			`phase_boots`,
             `soul_ring`,
             `magic_wand`,
-            `veil_of_discord`,
             `wind_lace`,
           ],
           mid_game: [
-            `eternal_shroud`,
-            `shivas_guard`,
-            `ultimate_scepter`,
+            `blade_mail`,
+			`eternal_shroud`,
+			`black_king_bar`,
             `blink`,
-            `black_king_bar`,
+            `ultimate_scepter`,
           ],
 
-          late_game: [`heart`, `aghanims_shard`, `kaya_and_sange`, `refresher`],
+          late_game: [`shivas_guard`, `wind_waker`, `aghanims_shard`, `refresher`],
           situational: [
-            `bracer`,
+            `veil_of_discord`,
             `vanguard`,
             `guardian_greaves`,
             `boots_of_bearing`,
             "lotus_orb",
             `ethereal_blade`,
-            `blade_mail`,
+			`kaya_and_sange`,
+			`sange_and_yasha`,
             `crimson_guard`,
             "pipe",
             "heavens_halberd",
             `radiance`,
             `cyclone`,
             `sphere`,
+			`heart`,
             `octarine_core`,
             `overwhelming_blink`,
             `travel_boots`,
@@ -13124,13 +13136,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           core: [
             `phase_boots`,
             `soul_ring`,
-            `veil_of_discord`,
+            `blade_mail`,
             `eternal_shroud`,
+			`black_king_bar`,
+			`blink`,
             `ultimate_scepter`,
-            `blink`,
-            `black_king_bar`,
-            `heart`,
-            `aghanims_shard`,
+            `shivas_guard`,
           ],
           neutral: [
             `occult_bracelet`,
@@ -13156,6 +13167,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40685,
         power_level: [0.9, 1.9, 2.2, 2.1],
+		facet: 1,
         abilities: [
           `primal_beast_trample`, // 1
           `primal_beast_onslaught`, // 2
@@ -13197,21 +13209,20 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `boots`,
             `magic_wand`,
             `ring_of_basilius`,
-            `wind_lace`,
             `infused_raindrop`,
           ],
           mid_game: [
             `arcane_boots`,
             `blink`,
             "black_king_bar",
-            `aghanims_shard`,
-            `force_staff`,
+            `blade_mail`,
+            `ultimate_scepter`,
           ],
           late_game: [
-            `ultimate_scepter`,
-            `boots_of_bearing`,
-            `ethereal_blade`,
+            `aghanims_shard`,
             `shivas_guard`,
+            `wind_waker`,
+            `refresher`,
           ],
           situational: [
             `soul_ring`,
@@ -13219,28 +13230,29 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `tranquil_boots`,
             `phase_boots`,
             `spirit_vessel`,
-            `blade_mail`,
+			`cyclone`,
+            `force_staff`,
+			`ancient_janggo`,
             `guardian_greaves`,
+			`boots_of_bearing`,
             `pipe`,
             `heavens_halberd`,
             `kaya_and_sange`,
+			`ethereal_blade`,
             `octarine_core`,
             `lotus_orb`,
             `heart`,
             `aeon_disk`,
-            `cyclone`,
             `overwhelming_blink`,
-            `refresher`,
             `travel_boots`,
           ],
           core: [
             `arcane_boots`,
             `blink`,
             `black_king_bar`,
-            `aghanims_shard`,
+			`blade_mail`,
             `ultimate_scepter`,
-            `boots_of_bearing`,
-            `ethereal_blade`,
+            `aghanims_shard`,
             `shivas_guard`,
           ],
           neutral: [
@@ -13287,8 +13299,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "black_king_bar",
           "orchid",
           "hurricane_pike",
-          "sange_and_yasha",
-          "kaya_and_sange",
+          `sange_and_yasha`,
         ],
       },
       late_game: {
@@ -14885,23 +14896,24 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40652,
         power_level: [1.7, 2.1, 2.4, 2.1],
+		facet: 2,
         abilities: [
           "sandking_burrowstrike", // 1
-          "sandking_caustic_finale", // 2
-          "sandking_sand_storm", // 3
-          "sandking_sand_storm", // 4
-          "sandking_sand_storm", // 5
+          `sandking_scorpion_strike`, // 2
+          `sandking_scorpion_strike`, // 3
+          `sandking_burrowstrike`, // 4
+          `sandking_scorpion_strike`, // 5
           "sandking_epicenter", // 6
-          "sandking_sand_storm", // 7
+          `sandking_scorpion_strike`, // 7
           "sandking_burrowstrike", // 8
           "sandking_burrowstrike", // 9
-          "sandking_burrowstrike", // 10
-          `special_bonus_unique_sand_king_burrowstrike_stun`, // 11
+          `sandking_sand_storm`, // 10
+          `sandking_sand_storm`, // 11
           "sandking_epicenter", // 12
-          "sandking_caustic_finale", // 13
-          "sandking_caustic_finale", // 14
-          `sandking_caustic_finale`, // 15
-          `special_bonus_unique_sand_king_3`, // 16
+          `sandking_sand_storm`, // 13
+          `sandking_sand_storm`, // 14
+          `special_bonus_unique_sand_king_burrowstrike_stun`, // 15
+          `special_bonus_unique_sand_king_scorpion_strike_damage`, // 16
           "special_bonus_attributes", // 17
           "sandking_epicenter", // 18
           "special_bonus_attributes", // 19
@@ -14925,31 +14937,29 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           early_game: [
             `bracer`,
             `bracer`,
-            `boots`,
+            `phase_boots`,
             `magic_wand`,
-            `veil_of_discord`,
             `wind_lace`,
           ],
-          mid_game: [`blink`, `travel_boots`, `aghanims_shard`, `shivas_guard`],
+          mid_game: [`blink`, `ultimate_scepter`, `eternal_shroud`, `bloodstone`, `aghanims_shard`],
           late_game: [
-            `ultimate_scepter`,
-            `kaya_and_sange`,
-            `octarine_core`,
+            `shivas_guard`,
             `wind_waker`,
+            `octarine_core`,
+            `black_king_bar`,
           ],
           situational: [
             `ring_of_basilius`,
             `arcane_boots`,
             `soul_ring`,
             `hand_of_midas`,
+			`veil_of_discord`,
             `vanguard`,
             `meteor_hammer`,
             `guardian_greaves`,
             `heavens_halberd`,
-            `black_king_bar`,
             `crimson_guard`,
             `pipe`,
-            `eternal_shroud`,
             `boots_of_bearing`,
             `ethereal_blade`,
             `cyclone`,
@@ -14959,18 +14969,17 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `heart`,
             `radiance`,
             `overwhelming_blink`,
-            `travel_boots_2`,
+            `travel_boots`,
           ],
           core: [
             `bracer`,
-            `boots`,
-            `veil_of_discord`,
+            `phase_boots`,
             "blink",
-            `travel_boots`,
+            `ultimate_scepter`,
+			`eternal_shroud`,
+			`bloodstone`,
             `aghanims_shard`,
             `shivas_guard`,
-            `ultimate_scepter`,
-            `octarine_core`,
           ],
           neutral: [
             `unstable_wand`,

--- a/content/messages.ts
+++ b/content/messages.ts
@@ -2844,16 +2844,16 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 10 * 60 + 10,
     repeatTime: 10 * 60,
     textMessage:
-      "In fights try to focus targets that you can burst such as supports or squishy heros without escapes.",
+      `In fights try to focus targets that you can burst such as supports or squishy heroes without escapes.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "clinkz_strafe" },
   },
   {
     category: `OwnHero`,
     npcHeroName: `clinkz`,
-    audioFile: `ownHero/Clinkz_7_BloodthornAggression`,
+    audioFile: `ownHero/Clinkz_7_DaedlusAggression`,
     messageTime: 21 * 60 + 10,
-    textMessage: `Use the Bloodthorn power spike to put pressure on the map by getting kill after kill on isolated enemy heroes.`,
+    textMessage: `Use the Daedlus power spike to put pressure on the map by getting kill after kill on isolated enemy heroes.`,
     audience: [Audience.ALL],
     image: { type: `item`, name: `bloodthorn` },
   },
@@ -3715,6 +3715,14 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audience: [Audience.ALL],
     image: { type: `ability`, name: `dazzle_bad_juju` },
   },
+  {
+    category: `OwnHero`,
+    npcHeroName: `dazzle`,
+    audioFile: `ownHero/Dazzle_11_OverHealFacet`,
+    messageTime: [25 * 60 + 15, 35 * 60 + 15, 45 * 60 + 15],
+    textMessage: `With the Nothl Boon facet, look to over heal your front line core when sieging or defending high ground to give them a damage barrier.`,
+    audience: [Audience.ALL],
+  },
 
   {
     category: "EnemyHero",
@@ -3722,7 +3730,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/Dazzle_1_PoisonTouch",
     messageTime: -60,
     textMessage:
-      "Avoid being hit by enemy heroes while under effect of Dazzle's Poison Touch.",
+      `Avoid being hit by Dazzle while under effect of Poison Touch. If he has the Poison Bloom facet, move away from him or hide in treelines before he attacks you four times.`,
     audience: [Audience.IN_LANE],
   },
   {
@@ -6684,7 +6692,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/KeeperOfTheLight_4_IlluminateVision",
     messageTime: [4 * 60 + 15, 12 * 60 + 15, 20 * 60 + 15],
     textMessage:
-      "Illuminate provides vision which can be used to check pillars for wards or Roshpit.",
+      `Illuminate provides vision which can be used to check pillars for wards or Roshan pit.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "keeper_of_the_light_illuminate" },
   },
@@ -6760,6 +6768,15 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audience: [Audience.ALL],
     image: { type: "ability", name: "keeper_of_the_light_blinding_light" },
   },
+  {
+    category: `OwnHero`,
+    npcHeroName: `keeper_of_the_light`,
+    audioFile: `ownHero/KeeperOfTheLight_12_RecallFacet`,
+    messageTime: [13 * 60 + 20, 23 * 60 + 20, 33 * 60 + 20, 43 * 60 + 20],
+    textMessage:
+      `If you have the Recall facet, look to split push lanes as much as you can to get an enemy hero to defend, and then Recall yourself elsewhere to gank or take a fight.`,
+    audience: [Audience.ALL],
+  },
 
   {
     category: "EnemyHero",
@@ -6824,7 +6841,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/KeeperOfTheLight_6_Recall",
     messageTime: [20 * 60 + 20, 30 * 60 + 20, 40 * 60 + 20],
     textMessage:
-      "Aghanim's Shard on Keeper of the Light grants Recall. He can teleport allied heroes to himself.",
+      `Be aware if Keeper of the Light has the Recall facet. He can bring multiple heroes to ganks or fights and beat you with a numbers advantage.`,
     audience: [Audience.ALL],
   },
 
@@ -10668,6 +10685,16 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
       "Use portals to roam between lanes and get kills with your Impale and Carapace setup.",
     audience: [Audience.ALL],
   },
+  {
+    category: `OwnHero`,
+    npcHeroName: `nyx_assassin`,
+    audioFile: `ownHero/NyxAssassin_11_MindFlareCreepSecure`,
+    messageTime: [3 * 60 + 15, 13 * 60 + 15],
+    textMessage:
+      `When not much is happening in the game, look to use Mind Flare to instantly kill some jungle creeps for some quick farm and experience.`,
+    audience: [Audience.ALL],
+	image: { type: `ability`, name: `nyx_assassin_jolt` },
+  },
 
   {
     category: "EnemyHero",
@@ -10678,14 +10705,14 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
       "Be careful not to use a major damaging spell when Spiked Carapace is on or Nyx Assassin is about to use it.",
     audience: [Audience.ALL],
   },
-  /*   {
+  {
     category: "EnemyHero",
     npcHeroName: "nyx_assassin",
     audioFile: "enemyHero/NyxAssassin_2_StickManaBoots",
     messageTime: 40,
-    textMessage: "To counter Nyx Assassin's mana burn, get a Magic Stick or Arcane Boots.",
+    textMessage: `To counter Nyx Assassin's mana burn facet, get a Magic Stick or Arcane Boots.`,
     audience: [Audience.ALL],
-  }, */
+  },
   {
     category: "EnemyHero",
     npcHeroName: "nyx_assassin",
@@ -10716,7 +10743,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/NyxAssassin_6_MindFlare",
     messageTime: 12 * 60,
     textMessage:
-      "Avoid buying too many intelligence giving items against Nyx Assassins Mind Flare.",
+      `Avoid buying too many mana pool increasing items against Nyx Assassins Mind Flare.`,
     audience: [Audience.ALL],
   },
 
@@ -11909,7 +11936,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/PrimalBeast_7_AghanimsShard",
     messageTime: 14 * 60 + 50,
     textMessage:
-      "Pick up Aghanim's Shard around minute 15 as it provides another disable among other things.",
+      `Pick up Aghanims Shard around later in the game as it provides another disable among other things.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "primal_beast_trample" },
   },
@@ -13005,7 +13032,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: "sand_king",
     audioFile: "ownHero/SandKing_2_CheckDetection",
     messageTime: [15, 8 * 60 + 15, 16 * 60 + 15],
-    textMessage: "Check opponents' inventories for detection frequently.",
+    textMessage: `Check opponents' inventories for detection frequently if you took the Sandshroud facet.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "SentryDustGem" },
   },
@@ -13015,7 +13042,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/SandKing_3_TagExplode",
     messageTime: [75, 3 * 60 + 15],
     textMessage:
-      "Tag creeps with Caustic Finale and if an opponent comes close, you can Burrowstrike and explode creeps.",
+      `Tag creeps with Caustic Finale and if an opponent comes close, you can Burrowstrike or Stinger to last hit and explode creeps.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "sandking_caustic_finale" },
   },
@@ -13035,7 +13062,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/SandKing_5_DefendTowers",
     messageTime: [8 * 60, 12 * 60],
     textMessage:
-      "Sand King is great at defending towers as you can Sand Storm in front and hide yourself in trees.",
+      `Sand King is great at defending towers as you can Sand Storm in front and hide yourself in trees with the Sandshroud facet.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "sandking_sand_storm" },
   },
@@ -13077,7 +13104,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: "sand_king",
     audioFile: "enemyHero/SandKing_1_Sentry",
     messageTime: -60,
-    textMessage: "Bring a sentry to the lane against Sand King's Sand Storm.",
+    textMessage: `Bring a sentry to the lane against Sand Kings Sand Storm if he took the Sandshroud facet.`,
     audience: [Audience.IN_LANE],
   },
   {
@@ -13104,7 +13131,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "enemyHero/SandKing_4_Detection",
     messageTime: [10 * 60 + 10, 18 * 60 + 10, 26 * 60 + 10],
     textMessage:
-      "Against Sand King you need to carry detection on multiple heroes.",
+      `Against Sand King you need to carry detection on multiple heroes if he took the Sandshroud facet.`,
     audience: [Audience.ALL],
   },
   {


### PR DESCRIPTION
Updated the guides for the following heroes:
Earth Spirit (Support)
Keeper of the Light (Support)
Nyx Assassin (Support)
Dazzle (Support)
Enchantress (Support)
Clinkz (Carry)
Primal Beast (Support & Offlane)
Sand King (Offlane)