### PR TITLE
Updated Hero Guides

### DIFF
--- a/content/heroBuilds.ts
+++ b/content/heroBuilds.ts
@@ -5410,6 +5410,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40575,
         power_level: [1.5, 1.9, 2.6, 2.8],
+		facet: 1,
         abilities: [
           `enigma_demonic_conversion`, // 1
           `enigma_malefice`, // 2
@@ -5449,35 +5450,39 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           early_game: [
             `bracer`,
+			`magic_wand`,
+			`ring_of_basilius`,
+			`vladmir`,
             `boots`,
-            `magic_wand`,
-            `ring_of_basilius`,
-            `urn_of_shadows`,
             `wind_lace`,
           ],
           mid_game: [
-            `vladmir`,
-            `arcane_boots`,
+            `ancient_janggo`,
+            `tranquil_boots`,
+			`boots_of_bearing`,
             `blink`,
-            `black_king_bar`,
-            `guardian_greaves`,
+            `aghanims_shard`,
           ],
           late_game: [
-            `aghanims_shard`,
+            `black_king_bar`,
             `refresher`,
             `octarine_core`,
             `ultimate_scepter`,
           ],
           situational: [
-            `spirit_vessel`,
+            `urn_of_shadows`,
+			`spirit_vessel`,
+			`arcane_boots`,
             `veil_of_discord`,
             `hand_of_midas`,
             `soul_ring`,
+			`mekansm`,
             `sphere`,
             `aeon_disk`,
             `invis_sword`,
             `helm_of_the_overlord`,
             `shivas_guard`,
+			`guardian_greaves`,
             `pipe`,
             `aether_lens`,
             `force_staff`,
@@ -5488,14 +5493,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           core: [
             `bracer`,
-            `boots`,
             `vladmir`,
-            `arcane_boots`,
-            `blink`,
+            `boots_of_bearing`,
+			`blink`,
+            `aghanims_shard`,
             `black_king_bar`,
-            `guardian_greaves`,
             `refresher`,
-            `octarine_core`,
           ],
           neutral: [
             `faded_broach`,
@@ -5517,6 +5520,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40576,
         power_level: [1.3, 1.8, 2.3, 2.6],
+		facet: 1,
         abilities: [
           "enigma_demonic_conversion", // 1
           "enigma_malefice", // 2
@@ -5549,10 +5553,10 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `tango`,
             `tango`,
             `blood_grenade`,
+			`faerie_fire`,
             `circlet`,
             `branches`,
             `branches`,
-            `enchanted_mango`,
             `ward_observer`,
             `ward_sentry`,
           ],
@@ -5565,24 +5569,26 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           mid_game: [
             `arcane_boots`,
+			`mekansm`,
             `blink`,
+			`guardian_greaves`,
             `vladmir`,
-            `guardian_greaves`,
             `black_king_bar`,
-            `aghanims_shard`,
           ],
           late_game: [
-            `refresher`,
+            `aghanims_shard`,
+			`refresher`,
             `octarine_core`,
             `ultimate_scepter`,
-            `aeon_disk`,
           ],
           situational: [
             `spirit_vessel`,
             `hand_of_midas`,
             `pavise`,
             `solar_crest`,
+			`ancient_janggo`,
             `sphere`,
+			`aeon_disk`,
             `invis_sword`,
             `shivas_guard`,
             `pipe`,
@@ -5595,12 +5601,11 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           core: [
             `arcane_boots`,
             `blink`,
+			`guardian_greaves`,
             `vladmir`,
-            `guardian_greaves`,
             `black_king_bar`,
             `aghanims_shard`,
             `refresher`,
-            `octarine_core`,
           ],
           neutral: [
             `faded_broach`,
@@ -8361,6 +8366,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40582,
         power_level: [1.6, 2.1, 2.1, 2.1],
+		facet: 1,
         abilities: [
           "lion_impale", // 1
           "lion_mana_drain", // 2
@@ -8372,7 +8378,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           `lion_impale`, // 8
           `lion_mana_drain`, // 9
           `lion_mana_drain`, // 10
-          `special_bonus_unique_lion_6`, // 11
+          `special_bonus_unique_lion_3`, // 11
           "lion_finger_of_death", // 12
           `lion_voodoo`, // 13
           `lion_voodoo`, // 14
@@ -8417,10 +8423,12 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `phylactery`,
             `glimmer_cape`,
             `ghost`,
+			`ancient_janggo`,
             `boots_of_bearing`,
             `lotus_orb`,
             `cyclone`,
             `black_king_bar`,
+			`wind_waker`,
             `travel_boots`,
           ],
           core: [
@@ -8436,7 +8444,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `faded_broach`,
             `mysterious_hat`,
             "philosophers_stone",
-            `whisper_of_the_dread`,
+            `vambrace`,
             "psychic_headband",
             `ceremonial_robe`,
             "timeless_relic",
@@ -8455,6 +8463,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
       `attack`,
       `lion_impale`,
       `lion_finger_of_death`,
+	  `lion_mana_drain`,
     ],
     counter_items: {
       laning_phase: {
@@ -12353,27 +12362,28 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40585,
         power_level: [1.7, 2.1, 2.5, 2.4],
+		facet: 1,
         abilities: [
           "pangolier_shield_crash", // 1
           "pangolier_swashbuckle", // 2
           "pangolier_shield_crash", // 3
           `pangolier_swashbuckle`, // 4
-          `pangolier_swashbuckle`, // 5
+          `pangolier_shield_crash`, // 5
           "pangolier_gyroshell", // 6
-          `pangolier_swashbuckle`, // 7
-          `pangolier_shield_crash`, // 8
-          `pangolier_shield_crash`, // 9
-          `special_bonus_unique_pangolier`, // 10
+          `pangolier_shield_crash`, // 7
+          `pangolier_swashbuckle`, // 8
+          `pangolier_swashbuckle`, // 9
+          `pangolier_lucky_shot`, // 10
           `pangolier_lucky_shot`, // 11
           "pangolier_gyroshell", // 12
           "pangolier_lucky_shot", // 13
           "pangolier_lucky_shot", // 14
-          `special_bonus_unique_pangolier_6`, // 15
-          "pangolier_lucky_shot", // 16
+          `special_bonus_unique_pangolier_luckyshot_armor`, // 15
+          `special_bonus_unique_pangolier_shield_crash_herostacks`, // 16
           "special_bonus_attributes", // 17
           "pangolier_gyroshell", // 18
           "special_bonus_attributes", // 19
-          `special_bonus_unique_pangolier_3`, // 20
+          `special_bonus_unique_pangolier_shield_crash_radius`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
@@ -12391,61 +12401,64 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ward_observer`,
           ],
           early_game: [
-            `wraith_band`,
             `bracer`,
-            `boots`,
+            `bracer`,
+            `power_treads`,
             `magic_wand`,
-            `ring_of_basilius`,
             `infused_raindrop`,
           ],
           mid_game: [
-            `arcane_boots`,
-            `diffusal_blade`,
+            `echo_sabre`,
             `blink`,
-            `ultimate_scepter`,
-            `basher`,
+			`manta`,
+			`aghanims_shard`,
           ],
           late_game: [
-            `aghanims_shard`,
-            `sphere`,
-            `disperser`,
-            `octarine_core`,
-            `overwhelming_blink`,
+            `ultimate_scepter`,
+            `shivas_guard`,
+            `harpoon`,
+            `abyssal_blade`,
           ],
           situational: [
-            `orb_of_corrosion`,
-            `power_treads`,
+            `wraith_band`,
+			`ring_of_basilius`,
+			`orb_of_corrosion`,
+            `arcane_boots`,
             `veil_of_discord`,
             `spirit_vessel`,
             `guardian_greaves`,
+			`cyclone`,
             `maelstrom`,
             `lotus_orb`,
+			`sphere`,
             `aeon_disk`,
             `pipe`,
             `crimson_guard`,
+			`assault`,
+			`diffusal_blade`,
+			`basher`,
             `heavens_halberd`,
-            `shivas_guard`,
-            `manta`,
+            `disperser`,
+            `octarine_core`,
             `black_king_bar`,
-            `arcane_blink`,
-            `cyclone`,
             `gungir`,
             `mjollnir`,
             `mage_slayer`,
+			`skadi`,
             `monkey_king_bar`,
             `satanic`,
-            `abyssal_blade`,
+			`arcane_blink`,
+            `overwhelming_blink`,
             `travel_boots`,
           ],
           core: [
             `bracer`,
-            `arcane_boots`,
-            `diffusal_blade`,
+            `power_treads`,
+            `echo_sabre`,
             `blink`,
+			`manta`,
+			`aghanims_shard`,
             `ultimate_scepter`,
-            `basher`,
-            `aghanims_shard`,
-            `disperser`,
           ],
           neutral: [
             `lance_of_pursuit`,
@@ -12454,7 +12467,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `orb_of_destruction`,
             `defiant_shell`,
             `paladin_sword`,
-            `mind_breaker`,
+            `ancient_guardian`,
             `havoc_hammer`,
             `desolator_2`,
             `apex`,
@@ -12467,6 +12480,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40584,
         power_level: [0.9, 1.8, 2, 2.1],
+		facet: 1,
         abilities: [
           "pangolier_shield_crash", // 1
           "pangolier_swashbuckle", // 2
@@ -12487,7 +12501,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           "special_bonus_attributes", // 17
           "pangolier_gyroshell", // 18
           "special_bonus_attributes", // 19
-          `special_bonus_unique_pangolier_3`, // 20
+          `special_bonus_unique_pangolier_shield_crash_radius`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
@@ -12515,18 +12529,21 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           mid_game: [
             `arcane_boots`,
+			`mekansm`,
+			`blink`,
             `guardian_greaves`,
-            `blink`,
             `cyclone`,
             `aghanims_shard`,
           ],
-          late_game: [`pipe`, `force_staff`, `octarine_core`, `gungir`],
+          late_game: [`pipe`, `gungir`,  `octarine_core`, `overwhelming_blink`],
           situational: [
-            `orb_of_corrosion`,
+            `blight_stone`,
+			`orb_of_corrosion`,
             `spirit_vessel`,
             `pavise`,
             `ghost`,
             `glimmer_cape`,
+			`force_staff`,
             `crimson_guard`,
             `vladmir`,
             `boots_of_bearing`,
@@ -12538,18 +12555,16 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `diffusal_blade`,
             `basher`,
             `ultimate_scepter`,
-            `overwhelming_blink`,
             `travel_boots`,
           ],
           core: [
             `arcane_boots`,
+			`blink`,
             `guardian_greaves`,
-            `blink`,
             `cyclone`,
             `aghanims_shard`,
             `pipe`,
             `octarine_core`,
-            `gungir`,
           ],
           neutral: [
             `arcane_ring`,
@@ -12571,27 +12586,28 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40570,
         power_level: [1.8, 2.2, 2.5, 2.4],
+		facet: 1,
         abilities: [
           "pangolier_shield_crash", // 1
           "pangolier_swashbuckle", // 2
           `pangolier_shield_crash`, // 3
           `pangolier_swashbuckle`, // 4
-          `pangolier_swashbuckle`, // 5
+          `pangolier_shield_crash`, // 5
           "pangolier_gyroshell", // 6
-          `pangolier_swashbuckle`, // 7
-          `pangolier_shield_crash`, // 8
-          `pangolier_shield_crash`, // 9
-          `special_bonus_unique_pangolier`, // 10
+          `pangolier_shield_crash`, // 7
+          `pangolier_swashbuckle`, // 8
+          `pangolier_swashbuckle`, // 9
+          `pangolier_lucky_shot`, // 10
           `pangolier_lucky_shot`, // 11
           "pangolier_gyroshell", // 12
           "pangolier_lucky_shot", // 13
           "pangolier_lucky_shot", // 14
-          `special_bonus_unique_pangolier_6`, // 15
-          "pangolier_lucky_shot", // 16
+          `special_bonus_unique_pangolier_luckyshot_armor`, // 15
+          `special_bonus_unique_pangolier_shield_crash_herostacks`, // 16
           "special_bonus_attributes", // 17
           "pangolier_gyroshell", // 18
           "special_bonus_attributes", // 19
-          "special_bonus_unique_pangolier_3", // 20
+          `special_bonus_unique_pangolier_shield_crash_radius`, // 20
           "special_bonus_attributes", // 21
           "special_bonus_attributes", // 22
           "special_bonus_attributes", // 23
@@ -12602,44 +12618,46 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           starting: [
             "tango",
             "quelling_blade",
-            `branches`,
-            `branches`,
-            `branches`,
             `faerie_fire`,
+            `branches`,
+            `branches`,
+            `branches`,
             `ward_observer`,
           ],
           early_game: [
             "bottle",
-            `boots`,
+            `power_treads`,
             `magic_wand`,
-            `ring_of_basilius`,
+            `blight_stone`,
             `infused_raindrop`,
           ],
           mid_game: [
-            `arcane_boots`,
-            `diffusal_blade`,
+            `echo_sabre`,
+			`manta`,
+			`desolator`,
             `blink`,
-            `ultimate_scepter`,
-            `basher`,
+			`ultimate_scepter`,
           ],
           late_game: [
             `aghanims_shard`,
-            `sphere`,
-            `disperser`,
-            `octarine_core`,
-            `overwhelming_blink`,
+            `harpoon`,
+			`assault`,
+            `abyssal_blade`,
           ],
           situational: [
-            `orb_of_corrosion`,
-            `power_treads`,
+            `ring_of_basilius`,
+			`orb_of_corrosion`,
+            `arcane_boots`,
             `spirit_vessel`,
             `maelstrom`,
             `guardian_greaves`,
-            `harpoon`,
+			`diffusal_blade`,
+			`basher`,
             `bloodthorn`,
-            `manta`,
+            `disperser`,
             `lotus_orb`,
             `black_king_bar`,
+			`sphere`,
             `aeon_disk`,
             `cyclone`,
             `shivas_guard`,
@@ -12648,19 +12666,21 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `mage_slayer`,
             `monkey_king_bar`,
             `satanic`,
-            `abyssal_blade`,
+			`greater_crit`,
+            `octarine_core`,
             `overwhelming_blink`,
             `travel_boots`,
           ],
           core: [
             `bottle`,
-            `arcane_boots`,
-            `diffusal_blade`,
+            `power_treads`,
+            `echo_sabre`,
+			`manta`,
+			`desolator`,
             `blink`,
-            `ultimate_scepter`,
-            `basher`,
+			`ultimate_scepter`,
             `aghanims_shard`,
-            `disperser`,
+			`assault`,
           ],
           neutral: [
             `lance_of_pursuit`,
@@ -12669,7 +12689,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `orb_of_destruction`,
             `defiant_shell`,
             `paladin_sword`,
-            `mind_breaker`,
+            `ancient_guardian`,
             `havoc_hammer`,
             `desolator_2`,
             `apex`,
@@ -18022,23 +18042,24 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40588,
         power_level: [2, 2.2, 2.7, 2.8],
+		facet: 2,
         abilities: [
           "tinker_laser", // 1
           "tinker_march_of_the_machines", // 2
-          "tinker_laser", // 3
-          "tinker_march_of_the_machines", // 4
-          "tinker_laser", // 5
+          `tinker_march_of_the_machines`, // 3
+          `tinker_laser`, // 4
+          `tinker_march_of_the_machines`, // 5
           "tinker_rearm", // 6   Note Michel: Use 'tinker_keen_teleport' instead of 'tinker_rearm'
-          "tinker_laser", // 7
-          "tinker_march_of_the_machines", // 8
-          "tinker_march_of_the_machines", // 9
-          `tinker_defense_matrix`, // 10
-          `special_bonus_mana_reduction_8`, // 11
+          `tinker_march_of_the_machines`, // 7
+          `tinker_laser`, // 8
+          `tinker_laser`, // 9
+          `special_bonus_unique_tinker_march_duration`, // 10
+          `tinker_defense_matrix`, // 11
           "tinker_rearm", // 12
           "tinker_defense_matrix", // 13
           "tinker_defense_matrix", // 14
-          `tinker_defense_matrix`, // 15
-          `special_bonus_unique_tinker_7`, // 16
+          `special_bonus_unique_tinker_4`, // 15
+          `tinker_defense_matrix`, // 16
           "special_bonus_attributes", // 17
           "tinker_rearm", // 18
           "special_bonus_attributes", // 19
@@ -18059,39 +18080,44 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `branches`,
             `ward_observer`,
           ],
-          early_game: [`bottle`, `blink`, `soul_ring`, `veil_of_discord`],
+          early_game: [`bottle`, `null_talisman`, `null_talisman`, `blink`],
           mid_game: [
-            `shivas_guard`,
+            `ultimate_scepter`,
             `aether_lens`,
-            `ethereal_blade`,
-            `overwhelming_blink`,
+			`kaya_and_sange`,
             `black_king_bar`,
+			`aghanims_shard`,
           ],
           late_game: [
-            `sheepstick`,
-            `ultimate_scepter`,
-            `dagon_5`,
-            `aghanims_shard`,
-            `wind_waker`,
+            `ethereal_blade`,
+			`arcane_blink`,
+			`sheepstick`,
+            `octarine_core`,
           ],
           situational: [
             `magic_wand`,
+			`soul_ring`,
+			`veil_of_discord`,
+			`phylactery`,
+			`angels_demise`,
             `force_staff`,
-            `kaya_and_sange`,
+            `dagon_5`,
             `aeon_disk`,
-            `arcane_blink`,
-            `bloodstone`,
+			`bloodstone`,
+			`shivas_guard`,
+			`sphere`,
+            `wind_waker`,
+			`overwhelming_blink`,
           ],
           core: [
             "bottle",
-            `blink`,
-            `soul_ring`,
-            `shivas_guard`,
-            `ethereal_blade`,
-            `overwhelming_blink`,
-            `black_king_bar`,
-            `sheepstick`,
+            `null_talisman`,
+			`blink`,
             `ultimate_scepter`,
+            `aether_lens`,
+			`kaya_and_sange`,
+            `black_king_bar`,
+            `arcane_blink`,
           ],
           neutral: [
             "mysterious_hat",
@@ -18108,7 +18134,13 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         },
       },
     ],
-    combo: [],
+    combo: [
+		`tinker_defense_matrix`,
+		`tinker_laser`,
+		`blink`,
+		`tinker_march_of_the_machines`,
+		`tinker_rearm`,
+	],
     /*
     // Needs to be reviewed, tinker_heat_seeking_missile doens't exists anymore and rearm items was also removed
     combo: [
@@ -18122,13 +18154,13 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
     ],*/
     counter_items: {
       laning_phase: {
-        all: ["ring_of_regen", "headdress", "infused_raindrop", "cloak"],
-        support: ["tranquil_boots", "smoke_of_deceit"],
+        all: [`ring_of_regen`, `headdress`, `cloak`],
+        support: [`tranquil_boots`],
         core: ["ring_of_health"],
       },
       mid_game: {
         all: ["lotus_orb", "blink"],
-        support: ["glimmer_cape", "smoke_of_deceit", "ward_observer"],
+        support: [`glimmer_cape`, `ward_observer`],
         core: [
           "mage_slayer",
           /* "hood_of_defiance", */
@@ -18144,7 +18176,6 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
       late_game: {
         all: ["sheepstick", "sphere", "aeon_disk"],
         support: [
-          "smoke_of_deceit",
           "ward_observer",
           "black_king_bar",
           "travel_boots",
@@ -18506,6 +18537,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.SUPPORT,
         dota_fire_id: 40580,
         power_level: [2, 2, 2.1, 2],
+		facet: 2,
         abilities: [
           `treant_leech_seed`, // 1
           `treant_natures_grasp`, // 2
@@ -18537,8 +18569,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           starting: [
             "tango",
             `blood_grenade`,
-            "orb_of_venom",
             `enchanted_mango`,
+            `wind_lace`,
             `branches`,
             "ward_observer",
             "ward_sentry",
@@ -18547,7 +18579,6 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `boots`,
             `magic_wand`,
             `ring_of_basilius`,
-            `wind_lace`,
             `infused_raindrop`,
           ],
           mid_game: [
@@ -18565,8 +18596,10 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `overwhelming_blink`,
           ],
           situational: [
-            `tranquil_boots`,
+            `orb_of_venom`,
+			`tranquil_boots`,
             `soul_ring`,
+			`mekansm`,
             `holy_locket`,
             `guardian_greaves`,
             `meteor_hammer`,
@@ -18583,7 +18616,6 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `aghanims_shard`,
             `solar_crest`,
             `blink`,
-            `force_staff`,
             `ultimate_scepter`,
             `refresher`,
             `octarine_core`,
@@ -18597,7 +18629,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             "ceremonial_robe",
             `timeless_relic`,
             `ascetic_cap`,
-            `demonicon`,
+            `book_of_shadows`,
             `force_boots`,
           ],
         },
@@ -20207,6 +20239,7 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.OFFLANE,
         dota_fire_id: 40572,
         power_level: [1.6, 2.4, 2.3, 2.1],
+		facet: 1,
         abilities: [
           "visage_soul_assumption", // 1
           "visage_grave_chill", // 2
@@ -20245,8 +20278,8 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ward_observer`,
           ],
           early_game: [
-            `wraith_band`,
             `bracer`,
+            `null_talisman`,
             `boots`,
             `magic_wand`,
             `ring_of_basilius`,
@@ -20254,49 +20287,52 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
           ],
           mid_game: [
             `vladmir`,
-            `orchid`,
-            `bloodthorn`,
+            `rod_of_atos`,
+			`maelstrom`,
+			`gungir`,
+			`assault`,
             `aghanims_shard`,
-            `ultimate_scepter`,
-            `ancient_janggo`,
           ],
-          late_game: [`sheepstick`, `assault`, `boots_of_bearing`, `nullifier`],
+          late_game: [`ancient_janggo`, `boots_of_bearing`, `ultimate_scepter`, `sheepstick`, `bloodthorn`],
           situational: [
-            `tranquil_boots`,
+            `wraith_band`,
+			`power_treads`,
+			`tranquil_boots`,
             `blight_stone`,
             `veil_of_discord`,
             `spirit_vessel`,
             `phylactery`,
+			`orchid`,
             `crimson_guard`,
-            `rod_of_atos`,
             `guardian_greaves`,
             `pipe`,
             `blink`,
+			`hurricane_pike`,
             `black_king_bar`,
             `aeon_disk`,
             `shivas_guard`,
+			`nullifier`,
             `travel_boots`,
           ],
           core: [
             `bracer`,
             `boots`,
             `vladmir`,
-            `bloodthorn`,
-            `aghanims_shard`,
-            `ultimate_scepter`,
-            `sheepstick`,
+            `gungir`,
             `assault`,
-            `boots_of_bearing`,
+            `aghanims_shard`,
+			`boots_of_bearing`,
+            `ultimate_scepter`,
           ],
           neutral: [
             `unstable_wand`,
             `spark_of_courage`,
             "grove_bow",
-            `orb_of_destruction`,
-            `elven_tunic`,
-            "enchanted_quiver",
+            `specialists_array`,
+            `enchanted_quiver`,
+            `nemesis_curse`,
             `mind_breaker`,
-            `trickster_cloak`,
+            `ancient_guardian`,
             `desolator_2`,
             `apex`,
           ],
@@ -20308,15 +20344,16 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
         steam_guide_role: STEAM_GUIDE_ROLE.CORE,
         dota_fire_id: 40589,
         power_level: [1.4, 2.4, 2.4, 2.1],
+		facet: 1,
         abilities: [
           "visage_grave_chill", // 1
           "visage_gravekeepers_cloak", // 2
           "visage_grave_chill", // 3
-          `visage_soul_assumption`, // 4
+          `visage_gravekeepers_cloak`, // 4
           "visage_grave_chill", // 5
           "visage_summon_familiars", // 6
           "visage_grave_chill", // 7
-          `visage_gravekeepers_cloak`, // 8
+          `visage_soul_assumption`, // 8
           `visage_gravekeepers_cloak`, // 9
           `special_bonus_unique_visage_8`, // 10
           `visage_gravekeepers_cloak`, // 11
@@ -20346,58 +20383,66 @@ export const heroBuilds: { [key: string]: IHeroContent } = {
             `ward_observer`,
           ],
           early_game: [
-            `wraith_band`,
             `bracer`,
+            `null_talisman`,
             `boots`,
             `magic_wand`,
-            `ring_of_basilius`,
             `wind_lace`,
           ],
           mid_game: [
-            `orchid`,
-            `bloodthorn`,
-            `vladmir`,
-            `ultimate_scepter`,
+            `maelstrom`,
+			`rod_of_atos`,
+            `gungir`,
+			`assault`,
             `aghanims_shard`,
-            `ancient_janggo`,
+			`travel_boots`,
           ],
-          late_game: [`sheepstick`, `assault`, `boots_of_bearing`, `nullifier`],
+          late_game: [`hurricane_pike`, `ultimate_scepter`, `sheepstick`, `bloodthorn`],
           situational: [
-            `tranquil_boots`,
+            `wraith_band`,
+			`ring_of_basilius`,
+			`power_treads`,
+			`tranquil_boots`,
             `power_treads`,
             `blight_stone`,
             `veil_of_discord`,
+			`vladmir`,
             `phylactery`,
             `crimson_guard`,
             `witch_blade`,
             `devastator`,
+			`orchid`,
+			`ancient_janggo`,
+            `boots_of_bearing`,
             `pipe`,
             `blink`,
             `black_king_bar`,
             `aeon_disk`,
+			`skadi`,
+			`monkey_king_bar`,
+			`nullifier`,
             `shivas_guard`,
-            `travel_boots`,
+            `travel_boots_2`,
           ],
           core: [
             `bracer`,
             `boots`,
-            `bloodthorn`,
-            `vladmir`,
-            `ultimate_scepter`,
+            `gungir`,
+			`assault`,
             `aghanims_shard`,
-            `sheepstick`,
-            `assault`,
-            `boots_of_bearing`,
+			`hurricane_pike`,
+            `ultimate_scepter`,
+			`sheepstick`,
           ],
           neutral: [
             `unstable_wand`,
             `spark_of_courage`,
             `grove_bow`,
-            `orb_of_destruction`,
-            `elven_tunic`,
+            `specialists_array`,
             `enchanted_quiver`,
+            `nemesis_curse`,
             `mind_breaker`,
-            `trickster_cloak`,
+            `ancient_guardian`,
             `desolator_2`,
             `apex`,
           ],

--- a/content/messages.ts
+++ b/content/messages.ts
@@ -5190,7 +5190,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 12 * 60,
     repeatTime: 10 * 60,
     textMessage:
-      "Be patient in teamfights, avoid showing too early and wait for opponets to clump up for your combo.",
+      `Be patient in teamfights, avoid showing too early and wait for opponents to clump up for your combo.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "enigma_black_hole" },
   },
@@ -7870,7 +7870,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: `lion`,
     audioFile: `ownHero/Lion_10_ManaDrainDamage`,
     messageTime: 2 * 60 + 15,
-    textMessage: `Position yourself to get an uninterrupted Mana Drain as a follow up on Earth Spike to harass enemy heroes from a distance.`,
+    textMessage: `With the Essence Eater facet, position yourself to get an uninterrupted Mana Drain as a follow up on Earth Spike to harass enemy heroes from a distance.`,
     audience: [Audience.ALL],
     image: { type: `ability`, name: `lion_mana_drain` },
   },
@@ -11317,7 +11317,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: "pangolier",
     audioFile: "ownHero/Pangolier_8_Roshan2",
     messageTime: 14 * 60 + 50,
-    textMessage: `Pick up Aghanims Shard at minute 15 as it gives you another survivability tool and reliably channel Rolling Thunder.`,
+    textMessage: `Pick up Aghanims Shard later in the game as it gives you another survivability tool and reliably channel Rolling Thunder.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
   },
@@ -16000,19 +16000,19 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     npcHeroName: "tinker",
     audioFile: "ownHero/Tinker_1_SecureRanged",
     messageTime: 15,
-    textMessage: `Secure ranged creep last hits with Laser and potentially harass the opponent at the same time.`,
+    textMessage: `You can use Laser to blind the enemy hero and secure or deny creeps while your opponent cannot do any right click damage.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "tinker_laser" },
   },
   {
     category: "OwnHero",
     npcHeroName: "tinker",
-    audioFile: "ownHero/Tinker_2_RocketHarass",
+    audioFile: `ownHero/Tinker_2_LaserHarass`,
     messageTime: 30,
     textMessage:
-      "If the opponents don't have great health regeneration, you can whittle them down with rocket spam.",
+      `If the enemy laner does not have great HP regeneration, you can whittle them down with Laser spam along with right clicks and March of the Machines.`,
     audience: [Audience.ALL],
-    image: { type: "ability", name: "tinker_heat_seeking_missile" },
+    image: { type: `ability`, name: `tinker_laser` },
   },
   {
     category: "OwnHero",
@@ -16020,9 +16020,9 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Tinker_3_Stacks",
     messageTime: [3 * 60 + 30, 6 * 60 + 30],
     textMessage:
-      "Ask your teammates to stack and make some yourself. You can clear ancients with maxed Laser under smoke.",
+      `Ask your teammates to stack and make some yourself. You can clear multiple jungle camps and ancients with March of the Machines.`,
     audience: [Audience.ALL],
-    image: { type: "ability", name: "tinker_laser" },
+    image: { type: `ability`, name: `tinker_march_of_the_machines` },
   },
   {
     category: "OwnHero",
@@ -16081,7 +16081,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: 12 * 60 + 15,
     repeatTime: 10 * 60,
     textMessage:
-      "Fight under your vision to be able to do more damage with rockets and position easier, even place wards yourself.",
+      `Fight under your vision to position yourself in a safe spot for the Laser and March of the Machines spam. You can even place the wards yourself.`,
     audience: [Audience.ALL],
     image: { type: "item", name: "ward_observer" },
   },
@@ -16189,7 +16189,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     textMessage: "Be aware of Tinker's Blink Dagger timing.",
     audience: [Audience.ALL],
   },
-  {
+  /* {
     category: "EnemyHero",
     npcHeroName: "tinker",
     audioFile: "enemyHero/Tinker_6_AvoidTrees",
@@ -16197,7 +16197,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     textMessage:
       "You can dodge Tinker's Heat-Seeking Missile by using Smoke of Deceit or blinking away.",
     audience: [Audience.ALL],
-  },
+  }, */
   {
     category: "EnemyHero",
     npcHeroName: "tinker",
@@ -16240,6 +16240,15 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     messageTime: [25 * 60 + 10, 35 * 60 + 10, 45 * 60 + 10],
     textMessage:
       "It is really hard to push highground against Tinker. Be patient and take fights outside the base.",
+    audience: [Audience.ALL],
+  },
+  {
+    category: `EnemyHero`,
+    npcHeroName: `tinker`,
+    audioFile: `enemyHero/Tinker_12_DisableAfterShield`,
+    messageTime: [21 * 60 + 10, 31 * 60 + 10, 41 * 60 + 10, 51 * 60 + 10],
+    textMessage:
+      `Against the Translocator facet, try to disable Tinker only after you break through his Defense Matrix as he gets a strong dispel when the shield expires.`,
     audience: [Audience.ALL],
   },
 
@@ -17710,7 +17719,7 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Visage_3_FamiliarsUsage",
     messageTime: [7 * 60 + 30, 17 * 60 + 30, 27 * 60 + 30],
     textMessage:
-      "Use familiars to control runes, stack camps, gank lanes even without your hero, drag and cut creepwaves.",
+      `With the Sepulchre facet, use familiars to control runes, stack camps, gank lanes even without your hero, drag and cut creepwaves.`,
     audience: [Audience.ALL],
     image: { type: "ability", name: "visage_summon_familiars" },
   },
@@ -17720,9 +17729,9 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
     audioFile: "ownHero/Visage_4_DontOverrotate",
     messageTime: [7 * 60 + 45, 11 * 60 + 45],
     textMessage:
-      "Don't over-rotate. Work your way to Orchid as it allows you to solo kill most of the heroes.",
+      `Try not to over rotate. Work your way to Gleipnir as it allows you to solo kill most of the heroes.`,
     audience: [Audience.ROLE_CORE],
-    image: { type: "item", name: "orchid" },
+    image: { type: `item`, name: `gungir` },
   },
   {
     category: "OwnHero",
@@ -17753,6 +17762,16 @@ export const dotaCoachMessages: DotaCoachMessage[] = [
       "Pick up Aghanims Shard later in the game as it allows you to survive jumps and provides another stun.",
     audience: [Audience.ALL],
     image: { type: "item", name: "aghanims_shard" },
+  },
+  {
+    category: `OwnHero`,
+    npcHeroName: `visage`,
+    audioFile: `ownHero/Visage_8_BootsofTravel`,
+    messageTime: 25 * 60 + 30,
+    textMessage:
+      `With Boots of Travel, you can TP around the map to join fight or split push and bring your Familiars to you with the alternate cast of Summon Familiars.`,
+    audience: [Audience.ALL],
+    image: { type: `item`, name: `travel_boots` },
   },
 
   {


### PR DESCRIPTION
Updated the guides for the following heroes:
Lion (Support)
Visage (Offlane & Mid)
Tinker (Mid)
Pangolier (Offlane, Mid & Support)
Enigma (Offlane & Support)
Treant Protector (Support)